### PR TITLE
feat: replace style will recover the origin style

### DIFF
--- a/src/resizer.js
+++ b/src/resizer.js
@@ -37,7 +37,6 @@ const styles = {
   topRight: {
     width: '20px',
     height: '20px',
-    position: 'absolute',
     right: '-10px',
     top: '-10px',
     cursor: 'ne-resize',
@@ -45,7 +44,6 @@ const styles = {
   bottomRight: {
     width: '20px',
     height: '20px',
-    position: 'absolute',
     right: '-10px',
     bottom: '-10px',
     cursor: 'se-resize',
@@ -53,7 +51,6 @@ const styles = {
   bottomLeft: {
     width: '20px',
     height: '20px',
-    position: 'absolute',
     left: '-10px',
     bottom: '-10px',
     cursor: 'sw-resize',
@@ -61,7 +58,6 @@ const styles = {
   topLeft: {
     width: '20px',
     height: '20px',
-    position: 'absolute',
     left: '-10px',
     top: '-10px',
     cursor: 'nw-resize',
@@ -88,8 +84,7 @@ export default (props: Props): React.Element<'div'> => {
       className={props.className}
       style={{
         ...styles.base,
-        ...styles[props.direction],
-        ...(props.replaceStyles || {}),
+        ...(props.replaceStyles || styles[props.direction]),
       }}
       onMouseDown={(e: SyntheticMouseEvent<HTMLDivElement>) => {
         props.onResizeStart(e, props.direction);


### PR DESCRIPTION
if replace style (handle style) are provided, origin style should be omitted.

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

inline style on `resizer` (`handleStyles`) could never be covered by style which set by`handleClasses`

```html
// style
.myHandle-right {
  width: 20px;
}

// react
<Resizable
  handleClasses={{right: 'myHandle-right'}}
/>
```

results like:

```html
// inline style set by origin right handle
{
  width: 10px;
}

// will be covered
.myHandle-right {
  width: 20px;
}
```

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

I should still write like these to make style in `myHandle-right` work:

```html
<Resizable
  handleStyles={{right: {}}}
  handleClasses={{right: 'myHandle-right'}}
/>
```

I'm not sure whether I should write like:

```
style={{
  ...styles.base,
  ...(props.className ? styles[props.direction] : {}),
  ...(props.replaceStyles || {})
}}
```

### Testing Done
<!-- How have you confirmed this feature works? -->

yes

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->