### PR TITLE
Fix using right click on resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,6 +268,13 @@ export default class Resizable extends React.Component<ResizableProps, State> {
     if (event.nativeEvent instanceof MouseEvent) {
       clientX = event.nativeEvent.clientX;
       clientY = event.nativeEvent.clientY;
+
+      // When user click with right button the resize is stuck in resizing mode
+      // until users clicks again, dont continue if right click is used.
+      if (event.nativeEvent.which === 3) {
+        return
+      }
+
     } else if (event.nativeEvent instanceof TouchEvent) {
       clientX = event.nativeEvent.touches[0].clientX;
       clientY = event.nativeEvent.touches[0].clientY;


### PR DESCRIPTION
When user clicks with right button the resize is stuck in resizing mode
until users clicks again. We will prevent resize mode.