### PR TITLE
Fixes #163 - additional height and width with lockAspectRatio

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 <p align="center"><a href="https://circleci.com/gh/bokuweb/re-resizable/tree/master">
 <img src="https://circleci.com/gh/bokuweb/re-resizable/tree/master.svg?style=svg" alt="Build Status" /></a>
 <a href="https://www.npmjs.com/package/re-resizable">
-<img src="https://img.shields.io/npm/v/re-resizable.svg" alt="Build Status" /></a> 
+<img src="https://img.shields.io/npm/v/re-resizable.svg" alt="Build Status" /></a>
 <a href="https://www.npmjs.com/package/re-resizable">
-<img src="https://img.shields.io/npm/dm/re-resizable.svg" /></a> 
+<img src="https://img.shields.io/npm/dm/re-resizable.svg" /></a>
 <a href="https://greenkeeper.io/">
-<img src="https://badges.greenkeeper.io/bokuweb/re-resizable.svg" /></a> 
+<img src="https://badges.greenkeeper.io/bokuweb/re-resizable.svg" /></a>
 </p>
 
 ## Table of Contents
@@ -27,7 +27,7 @@
 ## Demo
 
 ![screenshot](https://github.com/bokuweb/re-resizable/blob/master/docs/screenshot.gif?raw=true)
-   
+
 ## Install
 
 ``` sh
@@ -70,17 +70,17 @@ $ npm install --save re-resizable
 #### `defaultSize?: { width: (number | string), height: (number | string) };`
 
 Specifies the `width` and `height` that the dragged item should start at.
-For example, you can set `300`, `'300px'`, `50%`.   
-If both `defaultSize` and `size` omitted, set `'auto'`.    
-    
+For example, you can set `300`, `'300px'`, `50%`.
+If both `defaultSize` and `size` omitted, set `'auto'`.
+
 `defaultSize` will be ignored when `size` set.
 
 #### `size?: { width: (number | string), height: (number | string) };`
 
-The `size` property is used to set the size of the component.   
-For example, you can set `300`, `'300px'`, `50%`.   
+The `size` property is used to set the size of the component.
+For example, you can set `300`, `'300px'`, `50%`.
 
-Use `size` if you need to control size state by yourself.    
+Use `size` if you need to control size state by yourself.
 
 #### `className?: string;`
 
@@ -89,7 +89,7 @@ The `className` property is used to set the custom `className` of a resizable co
 #### `style?: { [key: string]: string };`
 
 The `style` property is used to set the custom `style` of a resizable component.
-   
+
 #### `minWidth?: number | string;`
 
 The `minWidth` property is used to set the minimum width of a resizable component.
@@ -110,10 +110,25 @@ The `maxHeight` property is used to set the maximum height of a resizable compon
 
 The `grid` property is used to specify the increments that resizing should snap to. Defaults to `[1, 1]`.
 
-#### `lockAspectRatio?: boolean;`
+#### `lockAspectRatio?: boolean | number;`
 
 The `lockAspectRatio` property is used to lock aspect ratio.
+Set to `true` to lock the aspect ratio based on the initial size.
+Set to a numeric value to lock a specific aspect ratio (such as `16/9`).
+If set to numeric, make sure to set initial height/width to values with correct aspect ratio.
 If omitted, set `false`.
+
+#### `lockAspectRatioExtraWidth?: number;`
+
+The `lockAspectRatioExtraWidth` property enables a resizable component to maintain an aspect ratio plus extra width.
+For instance, a video could be displayed 16:9 with a 50px side bar.
+If omitted, set `0`.
+
+#### `lockAspectRatioExtraHeight?: number;`
+
+The `lockAspectRatioExtraHeight` property enables a resizable component to maintain an aspect ratio plus extra height.
+For instance, a video could be displayed 16:9 with a 50px header bar.
+If omitted, set `0`.
 
 #### `bounds?: ('window' | 'parent' | HTMLElement);`
 
@@ -144,7 +159,7 @@ The `enable` property is used to set the resizable permission of a resizable com
 
 The permission of `top`, `right`, `bottom`, `left`, `topRight`, `bottomRight`, `bottomLeft`, `topLeft` direction resizing.
 If omitted, all resizer are enabled.
-If you want to permit only right direction resizing, set `{ top:false, right:true, bottom:false, left:false, topRight:false, bottomRight:false, bottomLeft:false, topLeft:false }`. 
+If you want to permit only right direction resizing, set `{ top:false, right:true, bottom:false, left:false, topRight:false, bottomRight:false, bottomLeft:false, topLeft:false }`.
 
 #### `onResizeStart?: ResizeStartCallBack;`
 
@@ -205,11 +220,11 @@ Update component size.
 class YourComponent extends Component {
 
   ...
-  
+
   update() {
     this.resizable.updateSize({ width: 200, height: 300 });
   }
-  
+
   render() {
     return (
       <Resizable ref={c => { this.resizable = c; }}>
@@ -325,7 +340,7 @@ You can add extendsProps as follows.
 
 - Remove offset state.
 - Use `border-box`.
-- Fix boundary size. 
+- Fix boundary size.
 
 #### v2.0.1
 
@@ -431,7 +446,7 @@ You can add extendsProps as follows.
 #### v0.4.2
 
 - Support react v15
-- ESLint run when push  
+- ESLint run when push
 
 #### v0.4.1
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,8 @@ export type ResizableProps = {
   maxWidth?: string | number;
   maxHeight?: string | number;
   lockAspectRatio?: boolean | number;
-  lockAspectRatioExtraWidth?: number;
-  lockAspectRatioExtraHeight?: number;
+  lockAspectRatioExtraWidth: number;
+  lockAspectRatioExtraHeight: number;
   enable?: Enable;
   handleStyles?: HandleStyles;
   handleClasses?: HandleClassName;

--- a/src/index.js
+++ b/src/index.js
@@ -390,14 +390,14 @@ export default class Resizable extends React.Component<ResizableProps, State> {
     const computedMaxHeight = (typeof maxHeight === 'undefined' || maxHeight < 0) ? newHeight : maxHeight;
 
     if (lockAspectRatio) {
-      const extraMinHeight = ((computedMinHeight - lockAspectRatioExtraHeight) * ratio) + lockAspectRatioExtraWidth;
-      const extraMaxHeight = ((computedMaxHeight - lockAspectRatioExtraHeight) * ratio) + lockAspectRatioExtraWidth;
-      const extraMinWidth = ((computedMinWidth - lockAspectRatioExtraWidth) / ratio) + lockAspectRatioExtraHeight;
-      const extraMaxWidth = ((computedMaxWidth - lockAspectRatioExtraWidth) / ratio) + lockAspectRatioExtraHeight;
-      const lockedMinWidth = computedMinWidth > extraMinHeight ? computedMinWidth : extraMinHeight;
-      const lockedMaxWidth = computedMaxWidth < extraMaxHeight ? computedMaxWidth : extraMaxHeight;
-      const lockedMinHeight = computedMinHeight > extraMinWidth ? computedMinHeight : extraMinWidth;
-      const lockedMaxHeight = computedMaxHeight < extraMaxWidth ? computedMaxHeight : extraMaxWidth;
+      const extraMinWidth = ((computedMinHeight - lockAspectRatioExtraHeight) * ratio) + lockAspectRatioExtraWidth;
+      const extraMaxWidth = ((computedMaxHeight - lockAspectRatioExtraHeight) * ratio) + lockAspectRatioExtraWidth;
+      const extraMinHeight = ((computedMinWidth - lockAspectRatioExtraWidth) / ratio) + lockAspectRatioExtraHeight;
+      const extraMaxHeight = ((computedMaxWidth - lockAspectRatioExtraWidth) / ratio) + lockAspectRatioExtraHeight;
+      const lockedMinWidth = Math.max(computedMinWidth, extraMinWidth);
+      const lockedMaxWidth = Math.min(computedMaxWidth, extraMaxWidth);
+      const lockedMinHeight = Math.max(computedMinHeight, extraMinHeight);
+      const lockedMaxHeight = Math.min(computedMaxHeight, extraMaxHeight);
       newWidth = clamp(newWidth, lockedMinWidth, lockedMaxWidth);
       newHeight = clamp(newHeight, lockedMinHeight, lockedMaxHeight);
     } else {

--- a/stories/index.js
+++ b/stories/index.js
@@ -23,6 +23,11 @@ import DefaultSizePercent from './default-size/percent-size';
 import SizeBasic from './size/basic';
 import SizePercent from './size/percent-size';
 
+import RatioBasic from './ratio/basic';
+import RatioFixed from './ratio/fixed';
+import RatioHeader from './ratio/header';
+import RatioSidebar from './ratio/sidebar';
+
 storiesOf('omit size', module)
   .add('auto.', () => <Auto />)
 
@@ -45,3 +50,9 @@ storiesOf('defaultSize', module)
 storiesOf('size', module)
   .add('basic.', () => <SizeBasic />)
   .add('percent size', () => <SizePercent />);
+
+storiesOf('lockAspectRatio', module)
+  .add('basic h:w is 2:1', () => <RatioBasic />)
+  .add('ratio is 16:9', () => <RatioFixed />)
+  .add('ratio is 16:9 with 50px header', () => <RatioHeader />)
+  .add('ratio is 16:9 with 50px header and sidebar', () => <RatioSidebar />);

--- a/stories/ratio/basic.js
+++ b/stories/ratio/basic.js
@@ -1,0 +1,25 @@
+/* eslint-disable */
+
+import React from 'react';
+import Resizable from '../../src';
+
+const style = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'solid 1px #ddd',
+  background: '#f0f0f0',
+};
+
+export default () => (
+  <Resizable
+    style={style}
+    defaultSize={{
+      width: 200,
+      height: 100,
+    }}
+    lockAspectRatio
+  >
+    001
+  </Resizable>
+);

--- a/stories/ratio/fixed.js
+++ b/stories/ratio/fixed.js
@@ -1,0 +1,28 @@
+/* eslint-disable */
+
+import React from 'react';
+import Resizable from '../../src';
+
+const style = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 0,
+  padding: 0,
+  background: '#f0f0f0',
+};
+
+const aspectRatio = 16 / 9;
+
+export default () => (
+  <Resizable
+    style={style}
+    defaultSize={{
+      width: 400,
+      height: (400 / aspectRatio),
+    }}
+    lockAspectRatio={aspectRatio}
+  >
+    001
+  </Resizable>
+);

--- a/stories/ratio/header.js
+++ b/stories/ratio/header.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+
+import React from 'react';
+import Resizable from '../../src';
+
+const style = {
+  display: 'flex',
+  flexDirection: 'column',
+  background: '#f0f0f0',
+  border: 0,
+  padding: 0,
+};
+
+const content = {
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const header = {
+  background: '#999999',
+  color: 'white',
+  height: '50px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const aspectRatio = 16 / 9;
+
+export default () => (
+  <Resizable
+    style={style}
+    defaultSize={{
+      width: 400,
+      height: (400 / aspectRatio) + 50,
+    }}
+    lockAspectRatio={aspectRatio}
+    lockAspectRatioExtraHeight={50}
+  >
+    <div style={header}>Header</div>
+    <div style={content}>001</div>
+  </Resizable>
+);

--- a/stories/ratio/sidebar.js
+++ b/stories/ratio/sidebar.js
@@ -1,0 +1,63 @@
+/* eslint-disable */
+
+import React from 'react';
+import Resizable from '../../src';
+
+const style = {
+  display: 'flex',
+  flexDirection: 'column',
+  background: '#f0f0f0',
+  border: 0,
+  padding: 0,
+};
+
+const wrapper = {
+  flex: 1,
+  display: 'flex'
+}
+
+const content = {
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+const header = {
+  background: '#666666',
+  color: 'white',
+  height: '50px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const sidebar = {
+  background: '#999999',
+  color: 'white',
+  width: '50px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const aspectRatio = 16 / 9;
+
+export default () => (
+  <Resizable
+    style={style}
+    defaultSize={{
+      width: 400 + 50,
+      height: (400 / aspectRatio) + 50,
+    }}
+    lockAspectRatio={aspectRatio}
+    lockAspectRatioExtraHeight={50}
+    lockAspectRatioExtraWidth={50}
+  >
+    <div style={header}>Header</div>
+    <div style={wrapper}>
+      <div style={sidebar}>Nav</div>
+      <div style={content}>001</div>
+    </div>
+  </Resizable>
+);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -544,6 +544,86 @@ test.serial('should aspect ratio locked when resize to right', async t => {
   t.deepEqual(onResize.getCall(0).args[3], { width: 200, height: 200 });
 });
 
+test.serial('should aspect ratio locked with 1:1 ratio when resize to right', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 100, height: 100 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      lockAspectRatio={1/1}
+    />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[2]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(200, 0);
+  mouseUp(200, 0);
+  t.is(onResizeStop.callCount, 1);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 300);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 300);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 200, height: 200 });
+});
+
+test.serial('should aspect ratio locked with 2:1 ratio when resize to right', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 200, height: 100 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      lockAspectRatio={2/1}
+    />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[2]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(200, 0);
+  mouseUp(200, 0);
+  t.is(onResizeStop.callCount, 1);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 400);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 200);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 200, height: 100 });
+});
+
+test.serial('should aspect ratio locked with 2:1 ratio with extra width/height when resize to right', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 250, height: 150 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      lockAspectRatio={2/1}
+      lockAspectRatioExtraHeight={50}
+      lockAspectRatioExtraWidth={50}
+      />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[2]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(200, 0);
+  mouseUp(200, 0);
+  t.is(onResizeStop.callCount, 1);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 450);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 250);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 200, height: 100 });
+});
+
 test.serial('should aspect ratio locked when resize to bottom', async t => {
   const onResize = sinon.spy();
   const onResizeStart = sinon.spy();
@@ -568,6 +648,86 @@ test.serial('should aspect ratio locked when resize to bottom', async t => {
   t.deepEqual(onResize.getCall(0).args[2].clientWidth, 300);
   t.deepEqual(onResize.getCall(0).args[2].clientHeight, 300);
   t.deepEqual(onResize.getCall(0).args[3], { width: 200, height: 200 });
+});
+
+test.serial('should aspect ratio locked with 1:1 ratio when resize to bottom', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 100, height: 100 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      lockAspectRatio={1/1}
+    />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[3]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(0, 200);
+  mouseUp(0, 200);
+  t.is(onResizeStop.callCount, 1);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 300);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 300);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 200, height: 200 });
+});
+
+test.serial('should aspect ratio locked with 2:1 ratio when resize to bottom', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 200, height: 100 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      lockAspectRatio={2/1}
+    />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[3]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(0, 200);
+  mouseUp(0, 200);
+  t.is(onResizeStop.callCount, 1);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 600);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 300);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 400, height: 200 });
+});
+
+test.serial('should aspect ratio locked with 2:1 ratio with extra width/height when resize to bottom', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 250, height: 150 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      lockAspectRatio={2/1}
+      lockAspectRatioExtraHeight={50}
+      lockAspectRatioExtraWidth={50}
+    />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[3]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(0, 200);
+  mouseUp(0, 200);
+  t.is(onResizeStop.callCount, 1);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 650);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 350);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 400, height: 200 });
 });
 
 test.serial('should clamped by parent width', async t => {


### PR DESCRIPTION
### Proposed solution

Adds support for additional height and width when locking a resizable component to an aspect ratio. An example use case is a window that contains a 16:9 video and has a 50px header.

Fixes #163 

### Tradeoffs

No significant tradeoffs. Width/height calculations are slightly more complex, but it should be negligible.

### Testing Done

Added 6 additional tests. Also added stories to the storybook that illustrate the feature in action. Updated docs. Verified lint and tests pass. 


