### PR TITLE
feat: Add a option for passing custom handle components

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ but other handle will still use the default styles.
 
 The `handleClasses` property is used to set the className of one or more resize handles.
 
+#### `handleComponent?: HandleComponent;`
+
+The `handleComponent` property is used to pass a React Component to be rendered as one or more resize handle. For example, this could be used to use an arrow icon as a handle..
+
 #### `handleWrapperStyle?: { [key: string]: string };`
 
 The `handleWrapperStyle` property is used to override the style of resize handles wrapper.

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,17 @@ type NumberSize = {
   height: number;
 }
 
+export type HandleComponent = {
+  top?: React.ElementType;
+  right?: React.ElementType;
+  bottom?: React.ElementType;
+  left?: React.ElementType;
+  topRight?: React.ElementType;
+  bottomRight?: React.ElementType;
+  bottomLeft?: React.ElementType;
+  topLeft?: React.ElementType;
+}
+
 export type ResizeCallback = (
   event: MouseEvent | TouchEvent,
   direction: Direction,
@@ -99,6 +110,7 @@ export type ResizableProps = {
   handleClasses?: HandleClassName;
   handleWrapperStyle?: Style;
   handleWrapperClass?: string;
+  handleComponent?: HandleComponent,
   children?: React.Node;
   onResizeStart?: ResizeStartCallback;
   onResize?: ResizeCallback;
@@ -490,7 +502,7 @@ export default class Resizable extends React.Component<ResizableProps, State> {
   }
 
   renderResizer(): React.Node {
-    const { enable, handleStyles, handleClasses, handleWrapperStyle, handleWrapperClass } = this.props;
+    const { enable, handleStyles, handleClasses, handleWrapperStyle, handleWrapperClass, handleComponent } = this.props;
     if (!enable) return null;
     const resizers = Object.keys(enable).map((dir: Direction): React$Node => {
       if (enable[dir] !== false) {
@@ -501,7 +513,10 @@ export default class Resizable extends React.Component<ResizableProps, State> {
             onResizeStart={this.onResizeStart}
             replaceStyles={handleStyles && handleStyles[dir]}
             className={handleClasses && handleClasses[dir]}
-          />
+          >{handleComponent && handleComponent[dir]
+              ? React.createElement(handleComponent[dir])
+              : null
+            }</Resizer>
         );
       }
       return null;

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ const definedProps = [
   'minWidth', 'minHeight', 'maxWidth', 'maxHeight', 'lockAspectRatio',
   'lockAspectRatioExtraWidth', 'lockAspectRatioExtraHeight',
   'enable', 'handleStyles', 'handleClasses', 'handleWrapperStyle',
-  'handleWrapperClass', 'children', 'onResizeStart', 'onResize', 'onResizeStop',
+  'handleWrapperClass', 'children', 'onResizeStart', 'onResize', 'onResizeStop', 'handleComponent',
 ];
 
 export default class Resizable extends React.Component<ResizableProps, State> {

--- a/src/resizer.js
+++ b/src/resizer.js
@@ -82,6 +82,7 @@ export type Props = {
   className?: string;
   replaceStyles?: { [key: string]: string | number };
   onResizeStart: OnStartCallback;
+  children: ?React.ChildrenArray<*>
 }
 
 export default (props: Props): React.Element<'div'> => {
@@ -99,6 +100,8 @@ export default (props: Props): React.Element<'div'> => {
       onTouchStart={(e: SyntheticTouchEvent<HTMLDivElement>) => {
         props.onResizeStart(e, props.direction);
       }}
-    />
+    >
+      {props.children}
+    </div>
   );
 };

--- a/stories/handle-component/bottom-right.js
+++ b/stories/handle-component/bottom-right.js
@@ -1,0 +1,59 @@
+/* eslint-disable */
+
+import React from 'react'
+import Resizable from '../../src'
+
+const style = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'solid 1px #ddd',
+  background: '#f0f0f0',
+}
+
+const SouthEastArrow = () => (
+  <svg
+    width="20px"
+    height="20px"
+    version="1.1"
+    viewBox="0 0 100 100"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="m70.129 67.086l1.75-36.367c-0.035156-2.6523-2.9414-3.6523-4.8164-1.7773l-8.4531 8.4531-17.578-17.574c-2.3438-2.3438-5.7188-1.5625-8.0586 0.78125l-13.078 13.078c-2.3438 2.3438-2.4141 5.0117-0.074219 7.3516l17.574 17.574-8.4531 8.4531c-1.875 1.875-0.83594 4.8203 1.8164 4.8555l36.258-1.8594c1.6836 0.019531 3.1328-1.2812 3.1133-2.9688z" />
+  </svg>
+)
+
+const CustomHandle = props => (
+  <div
+    style={{
+      background: '#fff',
+      borderRadius: '2px',
+      border: '1px solid #ddd',
+      height: '100%',
+      width: '100%',
+      padding: 0,
+    }}
+    className={'SomeCustomHandle'}
+    {...props}
+  />
+)
+const BottomRightHandle = () => (
+  <CustomHandle>
+    <SouthEastArrow />
+  </CustomHandle>
+)
+
+export default () => (
+  <Resizable
+    style={style}
+    defaultSize={{
+      width: 500,
+      height: 200,
+    }}
+    handleComponent={{
+      bottomRight: BottomRightHandle,
+    }}
+  >
+    bottomRight
+  </Resizable>
+)

--- a/stories/index.js
+++ b/stories/index.js
@@ -28,6 +28,8 @@ import RatioFixed from './ratio/fixed';
 import RatioHeader from './ratio/header';
 import RatioSidebar from './ratio/sidebar';
 
+import HandleComponentBottomRight from './handle-component/bottom-right';
+
 storiesOf('omit size', module)
   .add('auto.', () => <Auto />)
 
@@ -56,3 +58,6 @@ storiesOf('lockAspectRatio', module)
   .add('ratio is 16:9', () => <RatioFixed />)
   .add('ratio is 16:9 with 50px header', () => <RatioHeader />)
   .add('ratio is 16:9 with 50px header and sidebar', () => <RatioSidebar />);
+
+storiesOf('handleComponent', module)
+    .add('bottom right', () => <HandleComponentBottomRight />)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -789,3 +789,15 @@ test.serial('should defaultSize ignored when size set', async t => {
   t.is(divs[0].style.height, '300px');
   t.is(divs[0].style.position, 'relative');
 });
+
+test.serial('should render a handleComponent for right', async t => {
+  const CustomComponent = () => <div className={'customHandle-right'}/>
+  const resizable = TestUtils.renderIntoDocument(
+      <Resizable handleComponent={{right: CustomComponent}} />
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[2]);
+  const handleNode = node.children[0]
+  t.is(node.childElementCount, 1);
+  t.is(handleNode.getAttribute('class'), 'customHandle-right');
+});


### PR DESCRIPTION
### Proposed solution
Add an option for passing custom handle components  as requested on #161 by @mrodigin. This allows for rendering of icons or any component that you'd like at any existing handle location.

![Example](https://i.imgur.com/PFsaiSg.png)


### Tradeoffs
React Components's passed in for each handle at `handleComponent[dir]` are rendered using `React.createElement` while `renderResizer` is iterating over each direction. This approach doesn't allow for props to be passed to the custom handle component at runtime. I first set the component to be rendered at `handleComponent[dir].component` and props at `handleComponent[dir].props` but it felt like overkill, i'd expect that this is mostly useful for rendering icons. This would be easy enough to change though if props were considered necessary. 

### Testing Done

- Added a test to check if a custom component is rendered in expected position
- Added a storybook story as a visual test and example 


