### PR TITLE
fix #166, issues when resizing sometimes causes text-selection in som…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ const addResizeOverlay = (cursor: string) => {
     cursor: ${cursor || 'auto'};
     opacity: 0;
     position: fixed;
-    z-index: 9999,
+    z-index: 9999;
     top: 0;
     left: 0;
     bottom: 0;

--- a/src/index.js
+++ b/src/index.js
@@ -170,17 +170,17 @@ const addResizeOverlay = (cursor: string) => {
     left: 0;
     bottom: 0;
     right: 0;`;
-  if (body){
+  if (body) {
     body.appendChild(resizeOverlay);
   }
-}
+};
 
 const removeResizeOverlay = () => {
-  if (body && resizeOverlay){
+  if (body && resizeOverlay) {
     body.removeChild(resizeOverlay);
   }
   resizeOverlay = null;
-}
+};
 
 export default class Resizable extends React.Component<ResizableProps, State> {
   resizable: React.ElementRef<'div'>;

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,30 @@ const definedProps = [
   'handleWrapperClass', 'children', 'onResizeStart', 'onResize', 'onResizeStop', 'handleComponent',
 ];
 
+let resizeOverlay = null;
+
+const addResizeOverlay = (cursor: string) => {
+  resizeOverlay = document.createElement('div');
+  resizeOverlay.style.cssText = `
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0,0,0,0);
+    cursor: ${cursor || 'auto'};
+    opacity: 0;
+    position: fixed;
+    z-index: 9999,
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;`;
+  document.body.appendChild(resizeOverlay);
+}
+
+const removeResizeOverlay = () => {
+  document.body.removeChild(resizeOverlay);
+  resizeOverlay = null;
+}
+
 export default class Resizable extends React.Component<ResizableProps, State> {
   resizable: React.ElementRef<'div'>;
   onTouchMove: ResizeCallback;
@@ -330,7 +354,12 @@ export default class Resizable extends React.Component<ResizableProps, State> {
       isResizing: true,
       direction,
     });
+
+    const cursor = window.getComputedStyle(event.target).cursor;
+
+    addResizeOverlay(cursor);
   }
+
 
   onMouseMove(event: MouseEvent | TouchEvent) {
     if (!this.state.isResizing) return;
@@ -481,6 +510,7 @@ export default class Resizable extends React.Component<ResizableProps, State> {
       this.setState(this.props.size);
     }
     this.setState({ isResizing: false });
+    removeResizeOverlay();
   }
 
   get size(): NumberSize {

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,7 @@ const definedProps = [
   'handleWrapperClass', 'children', 'onResizeStart', 'onResize', 'onResizeStop', 'handleComponent',
 ];
 
+const body = document.body;
 let resizeOverlay = null;
 
 const addResizeOverlay = (cursor: string) => {
@@ -169,11 +170,15 @@ const addResizeOverlay = (cursor: string) => {
     left: 0;
     bottom: 0;
     right: 0;`;
-  document.body.appendChild(resizeOverlay);
+  if (body){
+    body.appendChild(resizeOverlay);
+  }
 }
 
 const removeResizeOverlay = () => {
-  document.body.removeChild(resizeOverlay);
+  if (body && resizeOverlay){
+    body.removeChild(resizeOverlay);
+  }
   resizeOverlay = null;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,7 @@ export type ResizableProps = {
 
 type State = {
   isResizing: boolean;
+  resizeCursor: string;
   direction: Direction;
   original: {
     x: number;
@@ -152,35 +153,6 @@ const definedProps = [
   'enable', 'handleStyles', 'handleClasses', 'handleWrapperStyle',
   'handleWrapperClass', 'children', 'onResizeStart', 'onResize', 'onResizeStop', 'handleComponent',
 ];
-
-const body = document.body;
-let resizeOverlay = null;
-
-const addResizeOverlay = (cursor: string) => {
-  resizeOverlay = document.createElement('div');
-  resizeOverlay.style.cssText = `
-    height: 100%;
-    width: 100%;
-    background-color: rgba(0,0,0,0);
-    cursor: ${cursor || 'auto'};
-    opacity: 0;
-    position: fixed;
-    z-index: 9999;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;`;
-  if (body) {
-    body.appendChild(resizeOverlay);
-  }
-};
-
-const removeResizeOverlay = () => {
-  if (body && resizeOverlay) {
-    body.removeChild(resizeOverlay);
-  }
-  resizeOverlay = null;
-};
 
 export default class Resizable extends React.Component<ResizableProps, State> {
   resizable: React.ElementRef<'div'>;
@@ -216,6 +188,7 @@ export default class Resizable extends React.Component<ResizableProps, State> {
     super(props);
     this.state = {
       isResizing: false,
+      resizeCursor: 'auto',
       width: typeof (this.propsSize && this.propsSize.width) === 'undefined'
         ? 'auto'
         : ((this.propsSize && this.propsSize.width): any),
@@ -357,12 +330,9 @@ export default class Resizable extends React.Component<ResizableProps, State> {
         height: this.size.height,
       },
       isResizing: true,
+      resizeCursor: window.getComputedStyle(event.target).cursor,
       direction,
     });
-
-    const cursor = window.getComputedStyle(event.target).cursor;
-
-    addResizeOverlay(cursor);
   }
 
 
@@ -514,8 +484,7 @@ export default class Resizable extends React.Component<ResizableProps, State> {
     if (this.props.size) {
       this.setState(this.props.size);
     }
-    this.setState({ isResizing: false });
-    removeResizeOverlay();
+    this.setState({ isResizing: false, resizeCursor: 'auto' });
   }
 
   get size(): NumberSize {
@@ -605,6 +574,24 @@ export default class Resizable extends React.Component<ResizableProps, State> {
         className={this.props.className}
         {...this.extendsProps}
       >
+        {this.state.isResizing &&
+        <div
+          style={{
+            height: '100%',
+            width: '100%',
+            backgroundColor: 'rgba(0,0,0,0)',
+            cursor: `${this.state.resizeCursor || 'auto'}`,
+            opacity: '0',
+            position: 'fixed',
+            zIndex: '9999',
+            top: '0',
+            left: '0',
+            bottom: '0',
+            right: '0',
+          }}
+        />
+        }
+
         {this.props.children}
         {this.renderResizer()}
       </div>


### PR DESCRIPTION
…e browsers

### Proposed solution
Fixes #166. I also noticed this behavior from time to time on both Firefox and Chrome on Windows.
The fix creates an invisible overlay that covers the entire page, while resizing the element. When resizing stops, the invisible overlay is removed. The cursor for the overlay is set to the same cursor as the handle that initiated the drag so it should not be visible to the user that this overlay is created.

### Tradeoffs
Not sure if there are any? z-index might not be high enough to cover all cases maybe?



### Testing Done
I have done manual testing only, as I cannot get the automated tests to run.


