### PR TITLE
added feature: absolute snap dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ The `maxHeight` property is used to set the maximum height of a resizable compon
 
 The `grid` property is used to specify the increments that resizing should snap to. Defaults to `[1, 1]`.
 
+#### `snap?: { x?: Array<number>, y?: Array<number> };`
+
+The `snap` property is used to specify absolute pixel values that resizing should snap to. `x` and `y` are both optional, allowing you to only include the axis you want to define. Defaults to `null`.
+
 #### `lockAspectRatio?: boolean | number;`
 
 The `lockAspectRatio` property is used to lock aspect ratio.
@@ -235,7 +239,7 @@ Calls when resizable component resize stop.
 
 Update component size.
 
-`grid` ,`max/minWidth`, `max/minHeight` props is ignored, when this method called.
+`grid`, `snap`, `max/minWidth`, `max/minHeight` props is ignored, when this method called.
 
 - for example
 
@@ -318,7 +322,7 @@ npm test
 
 #### v4.4.7
 
-- fix: #218 size not updated when zero props pass 
+- fix: #218 size not updated when zero props pass
 
 #### v4.4.6
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "re-resizable",
+  "name": "@therebel/re-resizable",
   "version": "4.7.1",
   "description": "Resizable component for React.",
   "title": "re-resizable",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@therebel/re-resizable",
+  "name": "re-resizable",
   "version": "4.7.1",
   "description": "Resizable component for React.",
   "title": "re-resizable",

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,10 @@ export type ResizableProps = {
   style?: Style,
   className?: string,
   grid?: [number, number],
+  snap?: {
+    x?: Array<number>,
+    y?: Array<number>,
+  },
   bounds?: 'parent' | 'window' | HTMLElement,
   size?: Size,
   minWidth?: string | number,
@@ -135,6 +139,8 @@ type State = {
 const clamp = (n: number, min: number, max: number): number => Math.max(Math.min(n, max), min);
 const snap = (n: number, size: number): number => Math.round(n / size) * size;
 
+const findClosestSnap = (n: number, snapArray: Array<number>): number => snapArray.reduce((prev, curr) => (Math.abs(curr - n) < Math.abs(prev - n) ? curr : prev));
+
 const endsWith = (str: string, searchStr: string): boolean =>
   str.substr(str.length - searchStr.length, searchStr.length) === searchStr;
 
@@ -148,6 +154,7 @@ const definedProps = [
   'style',
   'className',
   'grid',
+  'snap',
   'bounds',
   'size',
   'defaultSize',
@@ -499,6 +506,13 @@ export default class Resizable extends React.Component<ResizableProps, State> {
     }
     if (this.props.grid) {
       newHeight = snap(newHeight, this.props.grid[1]);
+    }
+
+    if (this.props.snap && this.props.snap.x) {
+      newWidth = findClosestSnap(newWidth, this.props.snap.x);
+    }
+    if (this.props.snap && this.props.snap.y) {
+      newHeight = findClosestSnap(newHeight, this.props.snap.y);
     }
 
     const delta = {

--- a/stories/default-size/absolute-snap.js
+++ b/stories/default-size/absolute-snap.js
@@ -1,0 +1,28 @@
+/* eslint-disable */
+
+import React from 'react';
+import Resizable from '../../src';
+
+const style = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'solid 1px #ddd',
+  background: '#f0f0f0',
+};
+
+export default () => (
+  <Resizable
+    style={style}
+    defaultSize={{
+      width: 200,
+      height: 200,
+    }}
+    snap={{
+      x: [10, 20, 50, 100, 300],
+      y: [10, 20, 50, 100, 300],
+    }}
+  >
+    [10, 20, 50, 100, 300]
+  </Resizable>
+);

--- a/stories/index.js
+++ b/stories/index.js
@@ -14,6 +14,7 @@ import DefaultSizeMaxHeight from './default-size/max-height';
 import DefaultSizeAutoWidth from './default-size/auto-width';
 import DefaultSizeAutoHeight from './default-size/auto-height';
 import DefaultSizeGrid from './default-size/grid';
+import DefaultSizeAbsoluteSnap from './default-size/absolute-snap';
 import DefaultSizeLockAspect from './default-size/lock-aspect';
 import DefaultSizeBoundsParent from './default-size/bounds-parent';
 import DefaultSizeMaxSizePercent from './default-size/max-size-percent';
@@ -47,6 +48,7 @@ storiesOf('defaultSize', module)
   .add('max width 400px.', () => <DefaultSizeMaxWidth />)
   .add('max height 400px.', () => <DefaultSizeMaxHeight />)
   .add('grid [10, 20].', () => <DefaultSizeGrid />)
+  .add('absolute snap {x y}.', () => <DefaultSizeAbsoluteSnap />)
   .add('lock aspect ratio w:h = 2:3', () => <DefaultSizeLockAspect />)
   .add('bounds parent', () => <DefaultSizeBoundsParent />)
   .add('max size percent', () => <DefaultSizeMaxSizePercent />)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -424,6 +424,30 @@ test.serial('should snapped by grid value', async t => {
   t.deepEqual(onResize.getCall(0).args[3], { width: 10, height: 10 });
 });
 
+test.serial('should snapped by absolute snap value', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render(
+    <Resizable
+      defaultSize={{ width: 100, height: 100 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      snap={{ x: [20, 30], y: [100] }}
+    />,
+    document.getElementById('content'),
+  );
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div');
+  const node = ReactDOM.findDOMNode(divs[6]);
+  TestUtils.Simulate.mouseDown(node, { clientX: 0, clientY: 0 });
+  mouseMove(12, 12);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 100);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 30);
+  t.deepEqual(onResize.getCall(0).args[3], { width: -70, height: 0 });
+});
+
 test.serial('should clamped by max width', async t => {
   const onResize = sinon.spy();
   const onResizeStart = sinon.spy();


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
This PR is aiming to allow defining absolute snap dimensions, rather than an infinite grid. It also allows for selective axis definition, so you can absolutely snap only the `x` axis, for example.

e.g. 

`grid={[1,5]}` will land on `[1, 5]`, `[2, 5]`, as well as `[40, 50]` ad infinitum.

`snap={{ x: [20, 30, 50], y: [10] }}` will only land on `[20, 10]`, `[30, 10]`, `[50, 10]`.

### Tradeoffs
Drawbacks: This solution puts priority of the absolute snap over the grid. Alternatively, it could snap to the defined grid after the absolute numbers, but I figured that'd be an odd developer experience since they're explicitly defining it to begin with.

There is an additional function added, `findClosestSnap` which does a reduce on the axis array. I've tried to keep this minimal and close to the `snap` function for ease of finding.

There is arguably a nomenclature disconnect between `grid` and `snap` props since both are technically "snapping". `snap` just seemed less verbose. I can change it if desired.

I'm also fairly sure I updated the types correctly, but I'm a typescript user rather than a flowtype user, it may need some tweaking.

### Testing Done
I have confirmed this works both in storybook (by adding a new story for it) and in my company's internal application under the npm module name `@therebel/re-resizable`. If this merges I'll update my application to use upstream ^_^

EDIT: I also added a new test to `test/index.test.js:427`

1. Pull the latest `master` branch: This was forked from `master` today.
4. If your PR fixes an issue, reference that issue: this isn't an open issue that I'm aware of. But I'll check again and update the PR with it if I find one. (EDIT: #319 probably has some overlap with this, though that sounds like a custom logic redefinition, rather than a property addition)


