### PR TITLE
Update for flow@0.82.0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,8 +186,8 @@ const baseClassName = '__resizable_base__';
 export default class Resizable extends React.Component<ResizableProps, State> {
   resizable: React.ElementRef<'div'>;
   onTouchMove: ResizeCallback;
-  onMouseMove: ResizeCallback;
-  onMouseUp: ResizeCallback;
+  onMouseMove: (event: MouseEvent | TouchEvent) => void;
+  onMouseUp: (event: MouseEvent | TouchEvent) => void;
   onResizeStart: OnStartCallback;
   extendsProps: { [key: string]: any };
 


### PR DESCRIPTION
Update type for onMouseMove and onMouseUp handlers for flow@0.82.0

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

Update types to match handler signatures to fix:

```js
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-rnd/node_modules/re-resizable/lib/index.es5.js.flow:178:3

Cannot shadow proto property onMouseMove [1] because function type [2] requires another argument from function [3].

    [2]  82│ export type ResizeCallback = (
         83│   event: MouseEvent | TouchEvent,
         84│   direction: Direction,
         85│   elementRef: React.ElementRef<'div'>,
         86│   delta: NumberSize,
         87│ ) => void;
           :
        175│ export default class Resizable extends React.Component<ResizableProps, State> {
        176│   resizable: React.ElementRef<'div'>;
        177│   onTouchMove: ResizeCallback;
        178│   onMouseMove: ResizeCallback;
        179│   onMouseUp: ResizeCallback;
        180│   onResizeStart: OnStartCallback;
        181│   extendsProps: { [key: string]: any };
           :
 [1][3] 390│   onMouseMove(event: MouseEvent | TouchEvent) {
        391│     if (!this.state.isResizing) return;
        392│     const clientX = event instanceof MouseEvent ? event.clientX : event.touches[0].clientX;
        393│     const clientY = event instanceof MouseEvent ? event.clientY : event.touches[0].clientY;
        394│     const { direction, original, width, height } = this.state;
        395│     const { lockAspectRatio, lockAspectRatioExtraHeight, lockAspectRatioExtraWidth } = this.props;
        396│     let { maxWidth, maxHeight, minWidth, minHeight } = this.props;
        397│
        398│     // TODO: refactor
        399│     const parentSize = this.getParentSize();
        400│     if (maxWidth && typeof maxWidth === 'string' && endsWith(maxWidth, '%')) {
        401│       const ratio = Number(maxWidth.replace('%', '')) / 100;
        402│       maxWidth = parentSize.width * ratio;
        403│     }
        404│     if (maxHeight && typeof maxHeight === 'string' && endsWith(maxHeight, '%')) {
           :
        509│
        510│     if (height && typeof height === 'string' && endsWith(height, '%')) {
        511│       const percent = newHeight / parentSize.height * 100;
        512│       newHeight = `${percent}%`;
        513│     }
        514│
        515│     this.setState({
        516│       width: this.calculateNewSize(newWidth, 'width'),
        517│       height: this.calculateNewSize(newHeight, 'height'),
        518│     });
        519│
        520│     if (this.props.onResize) {
        521│       this.props.onResize(event, direction, this.resizable, delta);
        522│     }
        523│   }


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-rnd/node_modules/re-resizable/lib/index.es5.js.flow:179:3

Cannot shadow proto property onMouseUp [1] because function type [2] requires another argument from function [3].

    [2]  82│ export type ResizeCallback = (
         83│   event: MouseEvent | TouchEvent,
         84│   direction: Direction,
         85│   elementRef: React.ElementRef<'div'>,
         86│   delta: NumberSize,
         87│ ) => void;
           :
        176│   resizable: React.ElementRef<'div'>;
        177│   onTouchMove: ResizeCallback;
        178│   onMouseMove: ResizeCallback;
        179│   onMouseUp: ResizeCallback;
        180│   onResizeStart: OnStartCallback;
        181│   extendsProps: { [key: string]: any };
        182│
           :
 [1][3] 525│   onMouseUp(event: MouseEvent | TouchEvent) {
        526│     const { isResizing, direction, original } = this.state;
        527│     if (!isResizing) return;
        528│     const delta = {
        529│       width: this.size.width - original.width,
        530│       height: this.size.height - original.height,
        531│     };
        532│     if (this.props.onResizeStop) {
        533│       this.props.onResizeStop(event, direction, this.resizable, delta);
        534│     }
        535│     if (this.props.size) {
        536│       this.setState(this.props.size);
        537│     }
        538│     this.setState({ isResizing: false, resizeCursor: 'auto' });
        539│   }
```

### Tradeoffs

n/a

### Testing Done

Edited the `re-resizable/lib/index.es5.js.flow` file directly and flow is now passing again.

