### PR TITLE
adjust intial left position of element to 0 for safari fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -302,7 +302,7 @@ export default class Resizable extends React.Component<ResizableProps, State> {
     element.style.height = '100%';
     element.style.position = 'absolute';
     element.style.transform = 'scale(0, 0)';
-    element.style.left = '-2147483647px';
+    element.style.left = '0';
     element.style.flex = '0';
     if (element.classList) {
       element.classList.add(baseClassName);


### PR DESCRIPTION
### Proposed solution
Set the initial `element.style.left` property on the resizable container / `__resizable_base__` to 0 from the previous `-2147483647px`

### Tradeoffs
In our specific use case (using this component, wrapped with a react-dnd component, on safari, our element was not draggable as the left position caused the draggable container to appear off-screen until manually adjusted to 0.


### Testing Done
I can confirm that this works in the context of our application specifically-- tested in Chrome (latest) and Safari (latest). I have not been able to test this against other projects, nor do I know the original use case for the starting left value being `-2147483647px`.

Feel free to let me know if you have any questions or concerns, and to disregard this PR if it creates other issues!

