### PR TITLE
Fix auto having "px" appended

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,7 @@ const endsWith = (str: string, searchStr: string): boolean =>
   str.substr(str.length - searchStr.length, searchStr.length) === searchStr;
 
 const getStringSize = (n: number | string): string => {
+  if (n.toString() === 'auto') return n.toString();
   if (endsWith(n.toString(), 'px')) return n.toString();
   if (endsWith(n.toString(), '%')) return n.toString();
   if (endsWith(n.toString(), 'vh')) return n.toString();


### PR DESCRIPTION
### Proposed solution
When putting `auto` as a size, it appends `px` after it, which is a problem, especially when going from a specific size (with `px`) and re-rendering back with `auto`, it kept the size.

### Testing Done
Tested with my branch on the Embark UI repo: https://github.com/embark-framework/embark/tree/features/resizable-editor-main

