### PR TITLE
fix: use event type to be more flexible

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -656,8 +656,8 @@ export class Resizable extends React.Component<ResizableProps, State> {
       return;
     }
     let { maxWidth, maxHeight, minWidth, minHeight } = this.props;
-    const clientX = event instanceof MouseEvent ? event.clientX : event.touches[0].clientX;
-    const clientY = event instanceof MouseEvent ? event.clientY : event.touches[0].clientY;
+    const clientX = event.type === 'mousemove' ? event.clientX : event.touches[0].clientX;
+    const clientY = event.type === 'mousemove' ? event.clientY : event.touches[0].clientY;
     const { direction, original, width, height } = this.state;
     const parentSize = this.getParentSize();
     const max = calculateNewMax(parentSize, maxWidth, maxHeight, minWidth, minHeight);


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

Closing https://github.com/bokuweb/re-resizable/issues/439

### Proposed solution
Use `event.type` as assertion rather than `instance of MouseEvent`


### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


