### PR TITLE
Add the possibility to limit snapping using a snapGap property

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ The `grid` property is used to specify the increments that resizing should snap 
 
 The `snap` property is used to specify absolute pixel values that resizing should snap to. `x` and `y` are both optional, allowing you to only include the axis you want to define. Defaults to `null`.
 
+#### `snapGap?: number`
+
+The `snapGap` property is used to specify the minimum gap required in order to move to the next snapping target. Defaults to `0` which means that snap targets are always used.
+
 #### `resizeRatio?: number | string;`
 
 The `resizeRatio` property is used to set the number of pixels the resizable component scales by compared to the number of pixels the mouse/touch moves. Defaults to `1` (for a 1:1 ratio). The number set is the left side of the ratio, `2` will give a 2:1 ratio.

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -519,6 +519,38 @@ test.serial('should snapped by absolute snap value', async t => {
   t.deepEqual(onResize.getCall(0).args[3], { width: -70, height: 0 });
 });
 
+test.serial('should only snap if the gap is small enough', async t => {
+  const onResize = sinon.spy();
+  const onResizeStart = sinon.spy();
+  const onResizeStop = sinon.spy();
+  const resizable = ReactDOM.render<ResizableProps, Resizable>(
+    <Resizable
+      defaultSize={{ width: 40, height: 40 }}
+      onResize={onResize}
+      onResizeStart={onResizeStart}
+      onResizeStop={onResizeStop}
+      grid={[40, 40]}
+      snapGap={10}
+    />,
+    document.getElementById('content'),
+  );
+  if (!resizable || resizable instanceof Element) return t.fail();
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div') as HTMLDivElement[];
+  const node = ReactDOM.findDOMNode(divs[6]);
+  if (!node || !(node instanceof HTMLDivElement)) return t.fail();
+  TestUtils.Simulate.mouseDown(node, { clientX: 40, clientY: 40 });
+  mouseMove(15, 15);
+  t.true(onResize.getCall(0).args[0] instanceof MouseEvent);
+  t.deepEqual(onResize.getCall(0).args[2].clientHeight, 55);
+  t.deepEqual(onResize.getCall(0).args[2].clientWidth, 55);
+  t.deepEqual(onResize.getCall(0).args[3], { width: 15, height: 15 });
+
+  mouseMove(35, 35);
+  t.deepEqual(onResize.getCall(1).args[2].clientHeight, 80);
+  t.deepEqual(onResize.getCall(1).args[2].clientWidth, 80);
+  t.deepEqual(onResize.getCall(1).args[3], { width: 40, height: 40 });
+});
+
 test.serial('should clamped by max width', async t => {
   const onResize = sinon.spy();
   const onResizeStart = sinon.spy();

--- a/stories/snap.stories.tsx
+++ b/stories/snap.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Resizable } from '../src';
+import { storiesOf } from '@storybook/react';
+import { style } from './style';
+
+storiesOf('snapping', module)
+    .add('absolute', () => (
+        <Resizable 
+            style={style} 
+            snap={{ x: [100, 300, 450], y: [100, 300, 450] }} 
+            snapGap={20}
+            defaultSize={{ width: 50, height: 50 }}
+        >
+            001
+        </Resizable>
+    ))
+    .add('grid', () => (
+        <Resizable 
+            style={style} 
+            grid={[100,100]} 
+            snapGap={20}
+            defaultSize={{ width: 50, height: 50 }}
+        >
+            001
+        </Resizable>
+    ));


### PR DESCRIPTION
Right now, the library allows snapping using `snap` or `grid` property but snapping is enforced. In this Pull Request, I'm adding a new `snapGap` prop that restricts the snapping behavior to a minimal gap between the computed size and the target snapping size.

![snapping](https://user-images.githubusercontent.com/272444/58798121-b619b600-85f9-11e9-8144-b528dc042d78.gif)

This property works for both `snap` and `grid` snapping behavior. 

I added storybook stories to showcase the behavior.
