### PR TITLE
Fixes #494 Add optional abort for onResizeStart

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -290,6 +290,24 @@ test.serial('Should only bottomRight is resizable and call onResizeStart when mo
   t.is(onResizeStart.getCall(0).args[1], 'bottomRight');
 });
 
+test.serial('Should not begin resize when onResizeStart returns false', async t => {
+  const onResizeStart = () => { return false; };
+  const onResize = sinon.spy();
+  const resizable = TestUtils.renderIntoDocument<ResizableProps, Resizable>(
+    <Resizable
+      onResizeStart={onResizeStart}
+      onResize={onResize}
+    />,
+  );
+  if (!resizable || resizable instanceof Element) return t.fail();
+  const divs = TestUtils.scryRenderedDOMComponentsWithTag(resizable, 'div') as HTMLDivElement[];
+  const previousState = resizable.state.isResizing;
+  TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(divs[1]) as Element);
+  mouseMove(200, 220);
+  t.is(onResize.callCount, 0);
+  t.is(resizable.state.isResizing, previousState);
+});
+
 test.serial('should call onResize with expected args when resize direction right', async t => {
   const onResize = sinon.spy();
   const onResizeStart = sinon.spy();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,7 +74,7 @@ export type ResizeStartCallback = (
   e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
   dir: Direction,
   elementRef: HTMLDivElement,
-) => void;
+) => void | boolean;
 
 export interface ResizableProps {
   style?: React.CSSProperties;
@@ -631,7 +631,10 @@ export class Resizable extends React.Component<ResizableProps, State> {
     }
     if (this.props.onResizeStart) {
       if (this.resizable) {
-        this.props.onResizeStart(event, direction, this.resizable);
+        const startResize = this.props.onResizeStart(event, direction, this.resizable);
+        if (startResize === false) {
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
Add optional return boolean when calling onResizeStart to early exit and abort the resize sequence

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
(From ticket #494)
Currently, when `onResizeStart` is called, the user provided [`onResizeStart`](https://github.com/bokuweb/re-resizable/blob/master/src/index.tsx#L634) (from `props`) is also called. In certain scenarios, however, some condition may be hit where the user wants to abort the resize.

The feature request would be to allow the user to return a boolean from their defined `onResizeStart`, and if it returns `false`, the re-resizable's `onResizeStart` would have an early exit and not cause any resizing.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
Should not add any overheard or tradeoffs. This `onResizeStart` is only stopped if the user returns an explicit `false`. I'm sure there are many cases where the return is undefined, which should be unaffected by this change.

### Testing Done
<!-- How have you confirmed this feature works? -->
Confirmed locally in project. Added a test that initiates a resize, but immediately aborts. While the 'user' continues to resize, it checks the state `isResizing` state of the Resizable (should be `false`).

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->