### PR TITLE
refactor: improve performance

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -414,30 +414,24 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     return size;
   }
 
-  public componentDidUpdate() {
+  public bindEvents() {
     if (typeof window !== 'undefined') {
-      if (this.state.isResizing) {
-        this.bindEvents();
-      } else {
-        this.unbindEvents();
-      }
+      window.addEventListener('mouseup', this.onMouseUp);
+      window.addEventListener('mousemove', this.onMouseMove);
+      window.addEventListener('mouseleave', this.onMouseUp);
+      window.addEventListener('touchmove', this.onMouseMove);
+      window.addEventListener('touchend', this.onMouseUp);
     }
   }
 
-  public bindEvents() {
-    window.addEventListener('mouseup', this.onMouseUp);
-    window.addEventListener('mousemove', this.onMouseMove);
-    window.addEventListener('mouseleave', this.onMouseUp);
-    window.addEventListener('touchmove', this.onMouseMove);
-    window.addEventListener('touchend', this.onMouseUp);
-  }
-
   public unbindEvents() {
-    window.removeEventListener('mouseup', this.onMouseUp);
-    window.removeEventListener('mousemove', this.onMouseMove);
-    window.removeEventListener('mouseleave', this.onMouseUp);
-    window.removeEventListener('touchmove', this.onMouseMove);
-    window.removeEventListener('touchend', this.onMouseUp);
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('mouseup', this.onMouseUp);
+      window.removeEventListener('mousemove', this.onMouseMove);
+      window.removeEventListener('mouseleave', this.onMouseUp);
+      window.removeEventListener('touchmove', this.onMouseMove);
+      window.removeEventListener('touchend', this.onMouseUp);
+    }
   }
 
   public componentDidMount() {
@@ -653,7 +647,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
 
     // For boundary
     this.setBoundingClientRect();
-
+    this.bindEvents();
     this.setState({
       original: {
         x: clientX,
@@ -770,6 +764,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     if (this.props.size) {
       this.setState(this.props.size);
     }
+    this.unbindEvents();
     this.setState({ isResizing: false, resizeCursor: 'auto' });
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -385,14 +385,6 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     this.onResizeStart = this.onResizeStart.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
-
-    if (typeof window !== 'undefined') {
-      window.addEventListener('mouseup', this.onMouseUp);
-      window.addEventListener('mousemove', this.onMouseMove);
-      window.addEventListener('mouseleave', this.onMouseUp);
-      window.addEventListener('touchmove', this.onMouseMove);
-      window.addEventListener('touchend', this.onMouseUp);
-    }
   }
 
   public getParentSize(): { width: number; height: number } {
@@ -420,6 +412,32 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     }
     this.base.style.minWidth = minWidth;
     return size;
+  }
+
+  public componentDidUpdate() {
+    if (typeof window !== "undefined") {
+      if (this.state.isResizing) {
+        this.bindEvents();
+      } else {
+        this.unbindEvents();
+      }
+    }
+  }
+
+  public bindEvents() {
+    window.addEventListener("mouseup", this.onMouseUp);
+    window.addEventListener("mousemove", this.onMouseMove);
+    window.addEventListener("mouseleave", this.onMouseUp);
+    window.addEventListener("touchmove", this.onMouseMove);
+    window.addEventListener("touchend", this.onMouseUp);
+  }
+
+  public unbindEvents() {
+    window.removeEventListener("mouseup", this.onMouseUp);
+    window.removeEventListener("mousemove", this.onMouseMove);
+    window.removeEventListener("mouseleave", this.onMouseUp);
+    window.removeEventListener("touchmove", this.onMouseMove);
+    window.removeEventListener("touchend", this.onMouseUp);
   }
 
   public componentDidMount() {
@@ -451,11 +469,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
 
   public componentWillUnmount() {
     if (typeof window !== 'undefined') {
-      window.removeEventListener('mouseup', this.onMouseUp);
-      window.removeEventListener('mousemove', this.onMouseMove);
-      window.removeEventListener('mouseleave', this.onMouseUp);
-      window.removeEventListener('touchmove', this.onMouseMove);
-      window.removeEventListener('touchend', this.onMouseUp);
+      this.unbindEvents();
       const parent = this.parentNode;
       if (!this.base || !parent) {
         return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -415,7 +415,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
   }
 
   public componentDidUpdate() {
-    if (typeof window !== "undefined") {
+    if (typeof window !== 'undefined') {
       if (this.state.isResizing) {
         this.bindEvents();
       } else {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -425,19 +425,19 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
   }
 
   public bindEvents() {
-    window.addEventListener("mouseup", this.onMouseUp);
-    window.addEventListener("mousemove", this.onMouseMove);
-    window.addEventListener("mouseleave", this.onMouseUp);
-    window.addEventListener("touchmove", this.onMouseMove);
-    window.addEventListener("touchend", this.onMouseUp);
+    window.addEventListener('mouseup', this.onMouseUp);
+    window.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('mouseleave', this.onMouseUp);
+    window.addEventListener('touchmove', this.onMouseMove);
+    window.addEventListener('touchend', this.onMouseUp);
   }
 
   public unbindEvents() {
-    window.removeEventListener("mouseup", this.onMouseUp);
-    window.removeEventListener("mousemove", this.onMouseMove);
-    window.removeEventListener("mouseleave", this.onMouseUp);
-    window.removeEventListener("touchmove", this.onMouseMove);
-    window.removeEventListener("touchend", this.onMouseUp);
+    window.removeEventListener('mouseup', this.onMouseUp);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseleave', this.onMouseUp);
+    window.removeEventListener('touchmove', this.onMouseMove);
+    window.removeEventListener('touchend', this.onMouseUp);
   }
 
   public componentDidMount() {


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
If we bind the mousemove event to `window`, it will always consume CPU while the mouse moving.
The solution is bind events after mousedown.

### Tradeoffs
N/A

### Testing Done
✅
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


