### PR TITLE
solving issue #537

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -829,6 +829,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
           minWidth: this.props.minWidth,
           minHeight: this.props.minHeight,
           boxSizing: 'border-box',
+          flexShrink: 0,
         }}
         className={this.props.className}
         {...extendsProps}

--- a/stories/multiple.stories.tsx
+++ b/stories/multiple.stories.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Resizable } from '../src';
+import { storiesOf } from '@storybook/react';
+import { style } from './style';
+
+storiesOf('multiple', module)
+  .add('horizontal', () => (
+    <div
+      style={{
+        width: '100%',
+        display: 'flex',
+        overflow: 'hidden',
+      }}
+    >
+      <Resizable
+        style={style}
+        defaultSize={{
+          width: '50%',
+          height: 200,
+        }}
+        maxWidth="100%"
+        minWidth="1"
+      >
+        001
+      </Resizable>
+      <div style={{ ...style, width: '100%', minWidth: '1px' }}>002</div>
+    </div>
+  ))
+  .add('vertical', () => (
+    <div
+      style={{
+        width: '300px',
+        height: '400px',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <Resizable
+        style={style}
+        defaultSize={{
+          width: '300',
+          height: '200',
+        }}
+        maxHeight="398"
+        minHeight="1"
+      >
+        001
+      </Resizable>
+      <div style={{ ...style, width: '300px', height: '100%', minHeight: '1px' }}>002</div>
+    </div>
+  ));


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
Fixes issue #537
The width of the  resizable element was not the same of the expected one since the css property **flex-shrink** defaults to 1, with this, if the element size was greater than other subsequent element, the new updated width would diverge from the one assigned to the style prop, the simple solution would be passing this property as 0 blocking this kind of behavior




### Testing Done
here is a gif showing what is the behavior after the fix:
![2019-11-28 14 37 23](https://user-images.githubusercontent.com/8769796/69826244-25f7aa80-11f1-11ea-921d-74eb0d13c359.gif)



