### PR TITLE
Fix ES Module Output Fixes #634

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES5",
+    "module": "es2015",
     "lib": ["es5", "es2015", "dom"],
     "jsx": "react",
     "declaration": true,


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

Fixes #634 

This solution, still builds the correct commonjs output because rollup will handle the module format conversion in that case.

### Tradeoffs
No tradeoffs, this will give the expected build.

### Testing Done

Tested locally.


