### PR TITLE
fix: instanceof check fails when window is a proxy

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -657,9 +657,13 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     }
     let clientX = 0;
     let clientY = 0;
-    if (event.nativeEvent && event.nativeEvent.clientX) {
-      clientX = event.nativeEvent.clientX;
-      clientY = event.nativeEvent.clientY;
+    if (event.nativeEvent) {
+      if ((event.nativeEvent.clientX || event.nativeEvent.clientX === 0)) {
+        clientX = event.nativeEvent.clientX;
+      }
+      if ((event.nativeEvent.clientY || event.nativeEvent.clientY === 0)) {
+        clientY = event.nativeEvent.clientY;
+      }
 
       // When user click with right button the resize is stuck in resizing mode
       // until users clicks again, dont continue if right click is used.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,6 +131,12 @@ const snap = memoize((n: number, size: number): number => Math.round(n / size) *
 const hasDirection = memoize((dir: 'top' | 'right' | 'bottom' | 'left', target: string): boolean =>
   new RegExp(dir, 'i').test(target),
 );
+const isTouchEvent = (event: MouseEvent | TouchEvent): event is TouchEvent => {
+  return Boolean((event as TouchEvent).touches && (event as TouchEvent).touches.length) 
+}
+const isMouseEvent = (event: MouseEvent | TouchEvent): event is MouseEvent => {
+  return Boolean(((event as MouseEvent).clientX || (event as MouseEvent).clientX === 0) && ((event as MouseEvent).clientY || (event as MouseEvent).clientY === 0))
+}
 
 const findClosestSnap = memoize((n: number, snapArray: number[], snapGap: number = 0): number => {
   const closestGapIndex = snapArray.reduce(
@@ -658,22 +664,19 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     let clientX = 0;
     let clientY = 0;
     if (event.nativeEvent) {
-      if ((event.nativeEvent.clientX || event.nativeEvent.clientX === 0)) {
+      if (isMouseEvent(event.nativeEvent)) {
         clientX = event.nativeEvent.clientX;
-      }
-      if ((event.nativeEvent.clientY || event.nativeEvent.clientY === 0)) {
         clientY = event.nativeEvent.clientY;
       }
-
       // When user click with right button the resize is stuck in resizing mode
       // until users clicks again, dont continue if right click is used.
       // HACK: MouseEvent does not have `which` from flow-bin v0.68.
       if (event.nativeEvent.which === 3) {
         return;
       }
-    } else if (event.nativeEvent && event.nativeEvent.touches && event.nativeEvent.touches.length) {
-      clientX = event.nativeEvent.touches[0].clientX;
-      clientY = event.nativeEvent.touches[0].clientY;
+    } else if (event.nativeEvent && isTouchEvent(event.nativeEvent)) {
+      clientX = (event.nativeEvent as TouchEvent).touches[0].clientX;
+      clientY = (event.nativeEvent as TouchEvent).touches[0].clientY;
     }
     if (this.props.onResizeStart) {
       if (this.resizable) {
@@ -734,7 +737,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     if (!this.state.isResizing || !this.resizable || !this.window) {
       return;
     }
-    if (this.window.TouchEvent && event.touches && event.touches.length) {
+    if (this.window.TouchEvent && isTouchEvent(event)) {
       try {
         event.preventDefault();
         event.stopPropagation();
@@ -743,8 +746,8 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       }
     }
     let { maxWidth, maxHeight, minWidth, minHeight } = this.props;
-    const clientX = (event.touches && event.touches.length) ? event.touches[0].clientX : event.clientX;
-    const clientY = (event.touches && event.touches.length) ? event.touches[0].clientY : event.clientY;
+    const clientX = isTouchEvent(event) ? event.touches[0].clientX : event.clientX;
+    const clientY = isTouchEvent(event) ? event.touches[0].clientY : event.clientY;
     const { direction, original, width, height } = this.state;
     const parentSize = this.getParentSize();
     const max = calculateNewMax(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,11 +134,15 @@ const hasDirection = memoize((dir: 'top' | 'right' | 'bottom' | 'left', target: 
 
 // INFO: In case of window is a Proxy and does not porxy Events correctly, use isTouchEvent & isMouseEvent to distinguish event type instead of `instanceof`.
 const isTouchEvent = (event: MouseEvent | TouchEvent): event is TouchEvent => {
-  return Boolean((event as TouchEvent).touches && (event as TouchEvent).touches.length) 
-}
+  return Boolean((event as TouchEvent).touches && (event as TouchEvent).touches.length);
+};
+
 const isMouseEvent = (event: MouseEvent | TouchEvent): event is MouseEvent => {
-  return Boolean(((event as MouseEvent).clientX || (event as MouseEvent).clientX === 0) && ((event as MouseEvent).clientY || (event as MouseEvent).clientY === 0))
-}
+  return Boolean(
+    ((event as MouseEvent).clientX || (event as MouseEvent).clientX === 0) &&
+      ((event as MouseEvent).clientY || (event as MouseEvent).clientY === 0),
+  );
+};
 
 const findClosestSnap = memoize((n: number, snapArray: number[], snapGap: number = 0): number => {
   const closestGapIndex = snapArray.reduce(
@@ -665,11 +669,9 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     }
     let clientX = 0;
     let clientY = 0;
-    if (event.nativeEvent) {
-      if (isMouseEvent(event.nativeEvent)) {
-        clientX = event.nativeEvent.clientX;
-        clientY = event.nativeEvent.clientY;
-      }
+    if (event.nativeEvent && isMouseEvent(event.nativeEvent)) {
+      clientX = event.nativeEvent.clientX;
+      clientY = event.nativeEvent.clientY;
       // When user click with right button the resize is stuck in resizing mode
       // until users clicks again, dont continue if right click is used.
       // HACK: MouseEvent does not have `which` from flow-bin v0.68.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -657,7 +657,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     }
     let clientX = 0;
     let clientY = 0;
-    if (event.nativeEvent instanceof this.window.MouseEvent) {
+    if (event.nativeEvent && event.nativeEvent.clientX) {
       clientX = event.nativeEvent.clientX;
       clientY = event.nativeEvent.clientY;
 
@@ -667,7 +667,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       if (event.nativeEvent.which === 3) {
         return;
       }
-    } else if (event.nativeEvent instanceof this.window.TouchEvent) {
+    } else if (event.nativeEvent && event.nativeEvent.touches && event.nativeEvent.touches.length) {
       clientX = event.nativeEvent.touches[0].clientX;
       clientY = event.nativeEvent.touches[0].clientY;
     }
@@ -730,7 +730,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     if (!this.state.isResizing || !this.resizable || !this.window) {
       return;
     }
-    if (this.window.TouchEvent && event instanceof this.window.TouchEvent) {
+    if (this.window.TouchEvent && event.touches && event.touches.length) {
       try {
         event.preventDefault();
         event.stopPropagation();
@@ -739,8 +739,8 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       }
     }
     let { maxWidth, maxHeight, minWidth, minHeight } = this.props;
-    const clientX = event instanceof this.window.MouseEvent ? event.clientX : event.touches[0].clientX;
-    const clientY = event instanceof this.window.MouseEvent ? event.clientY : event.touches[0].clientY;
+    const clientX = (event.touches && event.touches.length) ? event.touches[0].clientX : event.clientX;
+    const clientY = (event.touches && event.touches.length) ? event.touches[0].clientY : event.clientY;
     const { direction, original, width, height } = this.state;
     const parentSize = this.getParentSize();
     const max = calculateNewMax(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,6 +131,8 @@ const snap = memoize((n: number, size: number): number => Math.round(n / size) *
 const hasDirection = memoize((dir: 'top' | 'right' | 'bottom' | 'left', target: string): boolean =>
   new RegExp(dir, 'i').test(target),
 );
+
+// INFO: In case of window is a Proxy and does not porxy Events correctly, use isTouchEvent & isMouseEvent to distinguish event type instead of `instanceof`.
 const isTouchEvent = (event: MouseEvent | TouchEvent): event is TouchEvent => {
   return Boolean((event as TouchEvent).touches && (event as TouchEvent).touches.length) 
 }


### PR DESCRIPTION

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
window is a proxy in some micro-frontend scenes.
In such case, instanceof this.window.MouseEvent always return false.
Also, checking the exact property have better compatibility among different browsers


