### PR TITLE
Feature: boundsByDirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ If omitted, set `0`.
 
 Specifies resize boundaries.
 
+#### `boundsByDirection?: boolean;`
+
+By default max dimensions based on left and top element position.
+Width grow to right side, height grow to bottom side.
+Set `true` for detect max dimensions by direction.
+For example: enable `boundsByDirection` when resizable component stick on right side of screen and you want resize by left handler;
+
+`false` by default.
+
 #### `handleStyles?: HandleStyles;`
 
 The `handleStyles` property is used to override the style of one or more resize handles.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-resizable",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Resizable component for React.",
   "title": "re-resizable",
   "main": "./lib/index.es5.js",


### PR DESCRIPTION
bump version to 6.7.0

It PR about new feature.
Original behavior:

![Original behavior](https://media.giphy.com/media/CvhvdBc1BmayWZErdH/giphy.gif)

That behavior because window\`s right side close to resize component and component try resize like by right handler

`boundsByDirection` enabled behavior:

![Enabled behavior](https://i.giphy.com/media/2w2z2hfcUnHraKuhL6/giphy.webp)

### Testing Done
![Test](https://i.imgur.com/qQiJ8n5.png)


