### PR TITLE
Allow CTRL + click to be used for resizing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -689,12 +689,6 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     if (event.nativeEvent && isMouseEvent(event.nativeEvent)) {
       clientX = event.nativeEvent.clientX;
       clientY = event.nativeEvent.clientY;
-      // When user click with right button the resize is stuck in resizing mode
-      // until users clicks again, dont continue if right click is used.
-      // HACK: MouseEvent does not have `which` from flow-bin v0.68.
-      if (event.nativeEvent.which === 3) {
-        return;
-      }
     } else if (event.nativeEvent && isTouchEvent(event.nativeEvent)) {
       clientX = (event.nativeEvent as TouchEvent).touches[0].clientX;
       clientY = (event.nativeEvent as TouchEvent).touches[0].clientY;


### PR DESCRIPTION
Fixes #747

This is basically a revert of https://github.com/bokuweb/re-resizable/pull/152

Would be extremely happy if this can be merged and used by https://github.com/bokuweb/react-rnd  🙏