### PR TITLE
fix: Should alway follow lockAspectRatio

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -786,6 +786,13 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     // Calculate max size from boundary settings
     const boundaryMax = this.calculateNewMaxFromBoundary(maxWidth, maxHeight);
 
+    if (this.props.snap && this.props.snap.x) {
+      newWidth = findClosestSnap(newWidth, this.props.snap.x, this.props.snapGap);
+    }
+    if (this.props.snap && this.props.snap.y) {
+      newHeight = findClosestSnap(newHeight, this.props.snap.y, this.props.snapGap);
+    }
+
     // Calculate new size from aspect ratio
     const newSize = this.calculateNewSizeFromAspectRatio(
       newWidth,
@@ -802,13 +809,6 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       const gap = this.props.snapGap || 0;
       newWidth = gap === 0 || Math.abs(newGridWidth - newWidth) <= gap ? newGridWidth : newWidth;
       newHeight = gap === 0 || Math.abs(newGridHeight - newHeight) <= gap ? newGridHeight : newHeight;
-    }
-
-    if (this.props.snap && this.props.snap.x) {
-      newWidth = findClosestSnap(newWidth, this.props.snap.x, this.props.snapGap);
-    }
-    if (this.props.snap && this.props.snap.y) {
-      newHeight = findClosestSnap(newHeight, this.props.snap.y, this.props.snapGap);
     }
 
     const delta = {


### PR DESCRIPTION
Move snap before calculateNewSizeFromAspectRatio, that keeps new width and height follow lockAspectRatio

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
When set **lockAspectRatio** and **snap**, **snap** will break **lockAspectRatio**

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None

### Testing Done
<!-- How have you confirmed this feature works? -->
Absolutely works

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


