### PR TITLE
bugfix: calculate parent height even when the parent is a flex container

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -453,6 +453,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     }
     base.style.position = 'relative';
     base.style.minWidth = '100%';
+    base.style.minHeight = '100%';
     const size = {
       width: base.offsetWidth,
       height: base.offsetHeight,
@@ -513,7 +514,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     element.style.position = 'absolute';
     element.style.transform = 'scale(0, 0)';
     element.style.left = '0';
-    element.style.flex = '0';
+    element.style.flex = '0 0 100%';
     if (element.classList) {
       element.classList.add(baseClassName);
     } else {


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Fixes #764

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None.

### Testing Done
<!-- How have you confirmed this feature works? -->
I have confirmed that this fix works.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


