### PR TITLE
feat: support separate x and y resizeratio

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,6 +77,8 @@ export type ResizeStartCallback = (
   elementRef: HTMLElement,
 ) => void | boolean;
 
+export type ResizeRatio = number | { x?: number; y?: number };
+
 export interface ResizableProps {
   as?: string | React.ComponentType<any>;
   style?: React.CSSProperties;
@@ -109,7 +111,7 @@ export interface ResizableProps {
   onResizeStop?: ResizeCallback;
   defaultSize?: Size;
   scale?: number;
-  resizeRatio?: number;
+  resizeRatio?: ResizeRatio;
 }
 
 interface State {
@@ -589,25 +591,33 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     const extraHeight = lockAspectRatioExtraHeight || 0;
     const extraWidth = lockAspectRatioExtraWidth || 0;
     if (hasDirection('right', direction)) {
-      newWidth = original.width + ((clientX - original.x) * resizeRatio) / scale;
+      newWidth =
+        original.width +
+        ((clientX - original.x) * (typeof resizeRatio === 'number' ? resizeRatio : resizeRatio.x || 1)) / scale;
       if (lockAspectRatio) {
         newHeight = (newWidth - extraWidth) / this.ratio + extraHeight;
       }
     }
     if (hasDirection('left', direction)) {
-      newWidth = original.width - ((clientX - original.x) * resizeRatio) / scale;
+      newWidth =
+        original.width -
+        ((clientX - original.x) * (typeof resizeRatio === 'number' ? resizeRatio : resizeRatio.x || 1)) / scale;
       if (lockAspectRatio) {
         newHeight = (newWidth - extraWidth) / this.ratio + extraHeight;
       }
     }
     if (hasDirection('bottom', direction)) {
-      newHeight = original.height + ((clientY - original.y) * resizeRatio) / scale;
+      newHeight =
+        original.height +
+        ((clientY - original.y) * (typeof resizeRatio === 'number' ? resizeRatio : resizeRatio.y || 1)) / scale;
       if (lockAspectRatio) {
         newWidth = (newHeight - extraHeight) * this.ratio + extraWidth;
       }
     }
     if (hasDirection('top', direction)) {
-      newHeight = original.height - ((clientY - original.y) * resizeRatio) / scale;
+      newHeight =
+        original.height -
+        ((clientY - original.y) * (typeof resizeRatio === 'number' ? resizeRatio : resizeRatio.y || 1)) / scale;
       if (lockAspectRatio) {
         newWidth = (newHeight - extraHeight) * this.ratio + extraWidth;
       }


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
If the resizable component is centered, for example you have margin x auto, it resizes twice as fast, so the x ratio should be 2 instead of 1. While y ratio should stay 1. This implements the option to pass an object to resizeRatio of `{x?:number; y?:number}` so x and y axis can have a different resizeRatio.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
Users can keep providing a number to `resizeRatio` if they don't want to use this

### Testing Done
<!-- How have you confirmed this feature works? -->
Wrap resizable in a container and give it `margin-left: auto` and `margin-right: auto`, see how the handle does not stick to the cursor while resizing. Add `resizeRatio={{ x: 2 }}` and see now the handle moves with the cursor.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


