### PR TITLE
Add false to ResizableProps.enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The `handleWrapperStyle` property is used to override the style of resize handle
 
 The `handleWrapperClass` property is used to override the className of resize handles wrapper.
 
-#### `enable?: ?Enable;`
+#### `enable?: ?Enable | false;`
 
 The `enable` property is used to set the resizable permission of a resizable component.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -97,7 +97,7 @@ export interface ResizableProps {
   lockAspectRatio?: boolean | number;
   lockAspectRatioExtraWidth?: number;
   lockAspectRatioExtraHeight?: number;
-  enable?: Enable;
+  enable?: Enable | false;
   handleStyles?: HandleStyles;
   handleClasses?: HandleClassName;
   handleWrapperStyle?: React.CSSProperties;


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

In current behavior, all resizers are disabled if we pass `false` to `ResizableProps.enable`.
https://github.com/bokuweb/re-resizable/blob/da458ab823949ee1090316a3d50950ff89a04a7d/src/index.tsx#L888-L890
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

However current type definition does not accept `false` so I fixed the type.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

N/A

### Testing Done
<!-- How have you confirmed this feature works? -->

Tested with passing `false` to actual Resizable component.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->




