### PR TITLE
fix(index.tsx): make width and height properties optional in Size int…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ import { Resizable } from 're-resizable';
 </Resizable>
 ```
 
+If you only want to set the width, you can do so by providing just the width property. 
+The height property will automatically be set to auto, which means it will adjust 100% of its parent's height:
+
+```javascript
+import { Resizable } from 're-resizable';
+
+<Resizable
+  defaultSize={{
+    width: 320
+  }}
+>
+  Sample with default size
+</Resizable>
+```
 ### Example with `size`
 
 If you use `size` props, please manage state by yourself.
@@ -92,7 +106,7 @@ import { Resizable } from 're-resizable';
 
 ## Props
 
-#### `defaultSize?: { width: (number | string), height: (number | string) };`
+#### `defaultSize?: { width?: (number | string), height?: (number | string) };`
 
 Specifies the `width` and `height` that the dragged item should start at.
 For example, you can set `300`, `'300px'`, `50%`.
@@ -100,7 +114,7 @@ If both `defaultSize` and `size` omitted, set `'auto'`.
 
 `defaultSize` will be ignored when `size` set.
 
-#### `size?: { width: (number | string), height: (number | string) };`
+#### `size?: { width?: (number | string), height?: (number | string) };`
 
 The `size` property is used to set the size of the component.
 For example, you can set `300`, `'300px'`, `50%`.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,8 +44,8 @@ export interface HandleClassName {
 }
 
 export interface Size {
-  width: string | number;
-  height: string | number;
+  width?: string | number;
+  height?: string | number;
 }
 
 export interface NumberSize {
@@ -325,7 +325,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       if (typeof this.state[key] === 'undefined' || this.state[key] === 'auto') {
         return 'auto';
       }
-      if (this.propsSize && this.propsSize[key] && this.propsSize[key].toString().endsWith('%')) {
+      if (this.propsSize && this.propsSize[key] && this.propsSize[key]?.toString().endsWith('%')) {
         if (this.state[key].toString().endsWith('%')) {
           return this.state[key].toString();
         }
@@ -389,14 +389,8 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     super(props);
     this.state = {
       isResizing: false,
-      width:
-        typeof (this.propsSize && this.propsSize.width) === 'undefined'
-          ? 'auto'
-          : this.propsSize && this.propsSize.width,
-      height:
-        typeof (this.propsSize && this.propsSize.height) === 'undefined'
-          ? 'auto'
-          : this.propsSize && this.propsSize.height,
+      width:  this.propsSize?.width ?? 'auto',
+      height: this.propsSize?.height ?? 'auto',
       direction: 'right',
       original: {
         x: 0,
@@ -870,7 +864,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       this.props.onResizeStop(event, direction, this.resizable, delta);
     }
     if (this.props.size) {
-      this.setState(this.props.size);
+      this.setState({ width: this.props.size.width ?? 'auto', height: this.props.size.height ?? 'auto' });
     }
     this.unbindEvents();
     this.setState({
@@ -880,7 +874,7 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
   }
 
   updateSize(size: Size) {
-    this.setState({ width: size.width, height: size.height });
+    this.setState({ width: size.width ?? 'auto', height: size.height ?? 'auto' });
   }
 
   renderResizer() {


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
- currently Resizable get props defaultSize with width and height and must enter value for both of them
- In update: make width and height properties optional in Size interface to allow for undefined values and it allow user set value for one of them

- when i read and update the code, i realize that i can set "auto" for width and height, but i did not got it in any docs then, i think this make lib more flex to use
