### PR TITLE
Add `ref` to `definedProps`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -237,6 +237,7 @@ const normalizeToPair = <T,>(val: T | [T, T]): [T, T] => (Array.isArray(val) ? v
 
 const definedProps = [
   'as',
+  'ref',
   'style',
   'className',
   'grid',


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

Fixes `resizable` field always being `null` in React 18.3.

After [this React PR](https://github.com/facebook/react/pull/28348) for 18.3, `ref` is included as a normal prop. Because of this, we detect `ref` as a user-provided prop and break our ref logic. This causes the `resizable` field of our Resizable component to always read `null`. To fix this, we add `ref` to our defined props to ensure that we do not consider it a user-provided prop.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

There should be no negative effects from this change.

For all users with React < 18.3, it is impossible to pass `ref` in `props` as it is removed by React, so this change will not affect them. For all users with React >= 18.3, this will fix the behavior of `ref` in their resizable component.


### Testing Done
<!-- How have you confirmed this feature works? -->

Tested accessing the `resizable` field in both React 18.0 and 18.3. Both work!

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


