### PR TITLE
Define callback refs inline to work with latest versions of Next.js / React

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -926,12 +926,6 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     );
   }
 
-  ref = (c: HTMLElement | null) => {
-    if (c) {
-      this.resizable = c;
-    }
-  };
-
   render() {
     const extendsProps = Object.keys(this.props).reduce((acc, key) => {
       if (definedProps.indexOf(key) !== -1) {
@@ -961,7 +955,18 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
     const Wrapper = this.props.as || 'div';
 
     return (
-      <Wrapper ref={this.ref} style={style} className={this.props.className} {...extendsProps}>
+      <Wrapper
+        style={style}
+        className={this.props.className}
+        {...extendsProps}
+        // `ref` is after `extendsProps` to ensure this one wins over a version
+        // passed in
+        ref={(c: HTMLElement | null) => {
+          if (c) {
+            this.resizable = c;
+          }
+        }}
+      >
         {this.state.isResizing && <div style={this.state.backgroundStyle} />}
         {this.props.children}
         {this.renderResizer()}


### PR DESCRIPTION
Callback refs defined as class functions don't get invoked in Next.js 14.2+ – and therefore don't work – perhaps because of changes to the underlying React which is at or near version 19.

This should fix https://github.com/bokuweb/react-rnd/issues/941 along with the related PR on react-rnd: https://github.com/bokuweb/react-rnd/pull/942

Tested and confirmed to work with the latest stable version of Next.js 14.2.3