### PR TITLE
fix-boundary-scale: adds scaling to boundary Fixes #820

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -655,25 +655,25 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
       const parent = this.parentNode;
       if (parent) {
         const parentRect = parent.getBoundingClientRect();
-        this.parentLeft = parentRect.left;
-        this.parentTop = parentRect.top;
+        this.parentLeft = parentRect.left * (1 / this.props.scale);
+        this.parentTop = parentRect.top * (1 / this.props.scale);
       }
     }
 
     // For target(html element) boundary
     if (this.props.bounds && typeof this.props.bounds !== 'string') {
       const targetRect = this.props.bounds.getBoundingClientRect();
-      this.targetLeft = targetRect.left;
-      this.targetTop = targetRect.top;
+      this.targetLeft = targetRect.left * (1 / this.props.scale);
+      this.targetTop = targetRect.top * (1 / this.props.scale);
     }
 
     // For boundary
     if (this.resizable) {
       const { left, top, right, bottom } = this.resizable.getBoundingClientRect();
-      this.resizableLeft = left;
-      this.resizableRight = right;
-      this.resizableTop = top;
-      this.resizableBottom = bottom;
+      this.resizableLeft = left * (1 / this.props.scale);
+      this.resizableRight = right * (1 / this.props.scale);
+      this.resizableTop = top * (1 / this.props.scale);
+      this.resizableBottom = bottom * (1 / this.props.scale);
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -650,30 +650,32 @@ export class Resizable extends React.PureComponent<ResizableProps, State> {
   }
 
   setBoundingClientRect() {
+    const adjustedScale = 1 / (this.props.scale || 1);
+
     // For parent boundary
     if (this.props.bounds === 'parent') {
       const parent = this.parentNode;
       if (parent) {
         const parentRect = parent.getBoundingClientRect();
-        this.parentLeft = parentRect.left * (1 / this.props.scale);
-        this.parentTop = parentRect.top * (1 / this.props.scale);
+        this.parentLeft = parentRect.left * adjustedScale;
+        this.parentTop = parentRect.top * adjustedScale;
       }
     }
 
     // For target(html element) boundary
     if (this.props.bounds && typeof this.props.bounds !== 'string') {
       const targetRect = this.props.bounds.getBoundingClientRect();
-      this.targetLeft = targetRect.left * (1 / this.props.scale);
-      this.targetTop = targetRect.top * (1 / this.props.scale);
+      this.targetLeft = targetRect.left * adjustedScale;
+      this.targetTop = targetRect.top * adjustedScale;
     }
 
     // For boundary
     if (this.resizable) {
       const { left, top, right, bottom } = this.resizable.getBoundingClientRect();
-      this.resizableLeft = left * (1 / this.props.scale);
-      this.resizableRight = right * (1 / this.props.scale);
-      this.resizableTop = top * (1 / this.props.scale);
-      this.resizableBottom = bottom * (1 / this.props.scale);
+      this.resizableLeft = left * adjustedScale;
+      this.resizableRight = right * adjustedScale;
+      this.resizableTop = top * adjustedScale;
+      this.resizableBottom = bottom * adjustedScale;
     }
   }
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
This fixes #820 that I just filed. Basically when using a boundary element that has transform scale the bounding box is not what you expect. 


### Testing Done
Tested fix in my current project that uses this library, by modifying the index.js that is in the bundle with the same change. 




