### PR TITLE
fix: generated JSX namespace not working with React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "@storybook/addon-info": "5.3.21",
     "@storybook/addon-options": "5.3.21",
     "@storybook/react": "6.0.28",
-    "@types/node": "12.12.70",
-    "@types/react": "16.8.7",
-    "@types/react-dom": "17.0.9",
+    "@types/node": "20.17.19",
+    "@types/react": "19.0.10",
+    "@types/react-dom": "19.0.4",
     "@types/sinon": "9.0.10",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "8.1.0",
@@ -90,7 +90,7 @@
     "tslint-config-google": "1.0.1",
     "tslint-config-prettier": "1.18.0",
     "tslint-plugin-prettier": "2.3.0",
-    "typescript": "4.0.5"
+    "typescript": "5.7.3"
   },
   "typings": "./lib/index.d.ts",
   "types": "./lib/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,25 +40,25 @@ importers:
         version: 10.0.35(react@19.0.0)
       '@playwright/experimental-ct-react':
         specifier: ^1.43.1
-        version: 1.43.1(@types/node@12.12.70)(terser@5.30.4)(vite@5.2.10(@types/node@12.12.70)(terser@5.30.4))
+        version: 1.43.1(@types/node@20.17.19)(terser@5.30.4)(vite@5.2.10(@types/node@20.17.19)(terser@5.30.4))
       '@storybook/addon-info':
         specifier: 5.3.21
-        version: 5.3.21(@types/react@16.8.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(regenerator-runtime@0.14.1)
+        version: 5.3.21(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(regenerator-runtime@0.14.1)
       '@storybook/addon-options':
         specifier: 5.3.21
         version: 5.3.21(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(regenerator-runtime@0.14.1)
       '@storybook/react':
         specifier: 6.0.28
-        version: 6.0.28(@babel/core@7.11.6)(@types/react@16.8.7)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@4.0.5)
+        version: 6.0.28(@babel/core@7.11.6)(@types/react@19.0.10)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@types/node':
-        specifier: 12.12.70
-        version: 12.12.70
+        specifier: 20.17.19
+        version: 20.17.19
       '@types/react':
-        specifier: 16.8.7
-        version: 16.8.7
+        specifier: 19.0.10
+        version: 19.0.10
       '@types/react-dom':
-        specifier: 17.0.9
-        version: 17.0.9
+        specifier: 19.0.4
+        version: 19.0.4(@types/react@19.0.10)
       '@types/sinon':
         specifier: 9.0.10
         version: 9.0.10
@@ -139,7 +139,7 @@ importers:
         version: 2.2.0
       rollup-plugin-typescript2:
         specifier: 0.27.3
-        version: 0.27.3(rollup@1.32.1)(typescript@4.0.5)
+        version: 0.27.3(rollup@1.32.1)(typescript@5.7.3)
       rollup-watch:
         specifier: 4.3.1
         version: 4.3.1
@@ -148,7 +148,7 @@ importers:
         version: 9.0.3
       tslint:
         specifier: 6.1.3
-        version: 6.1.3(typescript@4.0.5)
+        version: 6.1.3(typescript@5.7.3)
       tslint-config-google:
         specifier: 1.0.1
         version: 1.0.1
@@ -157,10 +157,10 @@ importers:
         version: 1.18.0
       tslint-plugin-prettier:
         specifier: 2.3.0
-        version: 2.3.0(prettier@1.19.1)(tslint@6.1.3(typescript@4.0.5))
+        version: 2.3.0(prettier@1.19.1)(tslint@6.1.3(typescript@5.7.3))
       typescript:
-        specifier: 4.0.5
-        version: 4.0.5
+        specifier: 5.7.3
+        version: 5.7.3
 
 packages:
 
@@ -1584,8 +1584,8 @@ packages:
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
 
-  '@types/node@12.12.70':
-    resolution: {integrity: sha512-i5y7HTbvhonZQE+GnUM2rz1Bi8QkzxdQmEv1LKOv4nWyaQk/gdeiTApuQR3PDJHX7WomAbpx2wlWSEpxXGZ/UQ==}
+  '@types/node@20.17.19':
+    resolution: {integrity: sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1599,9 +1599,6 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
-  '@types/prop-types@15.7.12':
-    resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
-
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
@@ -1614,8 +1611,10 @@ packages:
   '@types/react-color@3.0.12':
     resolution: {integrity: sha512-pr3uKE3lSvf7GFo1Rn2K3QktiZQFFrSgSGJ/3iMvSOYWt2pPAJ97rVdVfhWxYJZ8prAEXzoP2XX//3qGSQgu7Q==}
 
-  '@types/react-dom@17.0.9':
-    resolution: {integrity: sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==}
+  '@types/react-dom@19.0.4':
+    resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
+    peerDependencies:
+      '@types/react': ^19.0.0
 
   '@types/react-syntax-highlighter@11.0.4':
     resolution: {integrity: sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==}
@@ -1623,8 +1622,8 @@ packages:
   '@types/react-textarea-autosize@4.3.6':
     resolution: {integrity: sha512-cTf8tCem0c8A7CERYbTuF+bRFaqYu7N7HLCa6ZhUhDx8XnUsTpGx5udMWljt87JpciUKuUkImKPEsy6kcKhrcQ==}
 
-  '@types/react@16.8.7':
-    resolution: {integrity: sha512-0xbkIyrDNKUn4IJVf8JaCn+ucao/cq6ZB8O6kSzhrJub1cVSqgTArtG0qCfdERWKMEIvUbrwLXeQMqWEsyr9dA==}
+  '@types/react@19.0.10':
+    resolution: {integrity: sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==}
 
   '@types/reactcss@1.2.12':
     resolution: {integrity: sha512-BrXUQ86/wbbFiZv8h/Q1/Q1XOsaHneYmCb/tHe9+M8XBAAUc2EHfdY0DY22ZZjVSaXr5ix7j+zsqO2eGZub8lQ==}
@@ -2816,6 +2815,9 @@ packages:
 
   csstype@2.6.21:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   cyclist@1.0.2:
     resolution: {integrity: sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==}
@@ -6064,9 +6066,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@4.0.5:
-    resolution: {integrity: sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ua-parser-js@0.7.37:
@@ -6074,6 +6076,9 @@ packages:
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
@@ -8015,10 +8020,10 @@ snapshots:
 
   '@emotion/sheet@0.9.4': {}
 
-  '@emotion/styled-base@10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)':
+  '@emotion/styled-base@10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.24.4
-      '@emotion/core': 10.0.35(react@16.14.0)
+      '@emotion/core': 10.0.35(react@19.0.0)
       '@emotion/is-prop-valid': 0.8.8
       '@emotion/serialize': 0.11.16
       '@emotion/utils': 0.11.3
@@ -8033,10 +8038,10 @@ snapshots:
       '@emotion/utils': 0.11.3
       react: 19.0.0
 
-  '@emotion/styled@10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)':
+  '@emotion/styled@10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)':
     dependencies:
-      '@emotion/core': 10.0.35(react@16.14.0)
-      '@emotion/styled-base': 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      '@emotion/core': 10.0.35(react@19.0.0)
+      '@emotion/styled-base': 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       babel-plugin-emotion: 10.2.2
       react: 16.14.0
 
@@ -8239,11 +8244,11 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
 
-  '@playwright/experimental-ct-core@1.43.1(@types/node@12.12.70)(terser@5.30.4)':
+  '@playwright/experimental-ct-core@1.43.1(@types/node@20.17.19)(terser@5.30.4)':
     dependencies:
       playwright: 1.43.1
       playwright-core: 1.43.1
-      vite: 5.2.10(@types/node@12.12.70)(terser@5.30.4)
+      vite: 5.2.10(@types/node@20.17.19)(terser@5.30.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8253,10 +8258,10 @@ snapshots:
       - sugarss
       - terser
 
-  '@playwright/experimental-ct-react@1.43.1(@types/node@12.12.70)(terser@5.30.4)(vite@5.2.10(@types/node@12.12.70)(terser@5.30.4))':
+  '@playwright/experimental-ct-react@1.43.1(@types/node@20.17.19)(terser@5.30.4)(vite@5.2.10(@types/node@20.17.19)(terser@5.30.4))':
     dependencies:
-      '@playwright/experimental-ct-core': 1.43.1(@types/node@12.12.70)(terser@5.30.4)
-      '@vitejs/plugin-react': 4.2.1(vite@5.2.10(@types/node@12.12.70)(terser@5.30.4))
+      '@playwright/experimental-ct-core': 1.43.1(@types/node@20.17.19)(terser@5.30.4)
+      '@vitejs/plugin-react': 4.2.1(vite@5.2.10(@types/node@20.17.19)(terser@5.30.4))
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8371,11 +8376,11 @@ snapshots:
 
   '@sinonjs/text-encoding@0.7.2': {}
 
-  '@storybook/addon-info@5.3.21(@types/react@16.8.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(regenerator-runtime@0.14.1)':
+  '@storybook/addon-info@5.3.21(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(regenerator-runtime@0.14.1)':
     dependencies:
       '@storybook/addons': 5.3.21(react-dom@19.0.0(react@19.0.0))(regenerator-runtime@0.14.1)
       '@storybook/client-logger': 5.3.21
-      '@storybook/components': 5.3.21(@types/react@16.8.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@storybook/components': 5.3.21(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storybook/theming': 5.3.21(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       core-js: 3.37.0
       global: 4.4.0
@@ -8569,7 +8574,7 @@ snapshots:
       core-js: 3.37.0
       global: 4.4.0
 
-  '@storybook/components@5.3.21(@types/react@16.8.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@storybook/components@5.3.21(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@storybook/client-logger': 5.3.21
       '@storybook/theming': 5.3.21(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -8585,7 +8590,7 @@ snapshots:
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-focus-lock: 2.12.1(@types/react@16.8.7)(react@19.0.0)
+      react-focus-lock: 2.12.1(@types/react@19.0.10)(react@19.0.0)
       react-helmet-async: 1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-popper-tooltip: 2.11.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-syntax-highlighter: 11.0.3(react@19.0.0)
@@ -8595,7 +8600,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/components@6.0.28(@types/react@16.8.7)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@storybook/components@6.0.28(@types/react@19.0.10)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@storybook/client-logger': 6.0.28
       '@storybook/csf': 0.0.1
@@ -8617,12 +8622,12 @@ snapshots:
       react-dom: 16.14.0(react@16.14.0)
       react-popper-tooltip: 2.11.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react-syntax-highlighter: 12.2.1(react@16.14.0)
-      react-textarea-autosize: 8.5.3(@types/react@16.8.7)(react@16.14.0)
+      react-textarea-autosize: 8.5.3(@types/react@19.0.10)(react@16.14.0)
       ts-dedent: 1.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/components@6.0.28(@types/react@16.8.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@storybook/components@6.0.28(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@storybook/client-logger': 6.0.28
       '@storybook/csf': 0.0.1
@@ -8644,7 +8649,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       react-popper-tooltip: 2.11.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-syntax-highlighter: 12.2.1(react@19.0.0)
-      react-textarea-autosize: 8.5.3(@types/react@16.8.7)(react@19.0.0)
+      react-textarea-autosize: 8.5.3(@types/react@19.0.10)(react@19.0.0)
       ts-dedent: 1.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -8657,7 +8662,7 @@ snapshots:
     dependencies:
       core-js: 3.37.0
 
-  '@storybook/core@6.0.28(@babel/core@7.11.6)(@types/react@16.8.7)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@4.0.5)':
+  '@storybook/core@6.0.28(@babel/core@7.11.6)(@types/react@19.0.10)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.11.6
       '@babel/plugin-proposal-class-properties': 7.10.4(@babel/core@7.11.6)
@@ -8687,14 +8692,14 @@ snapshots:
       '@storybook/channels': 6.0.28
       '@storybook/client-api': 6.0.28(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storybook/client-logger': 6.0.28
-      '@storybook/components': 6.0.28(@types/react@16.8.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@storybook/components': 6.0.28(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storybook/core-events': 6.0.28
       '@storybook/csf': 0.0.1
       '@storybook/node-logger': 6.0.28
       '@storybook/router': 6.0.28(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.0.28(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@storybook/ui': 6.0.28(@types/react@16.8.7)
+      '@storybook/ui': 6.0.28(@types/react@19.0.10)
       '@types/glob-base': 0.3.2
       '@types/micromatch': 4.0.7
       '@types/node-fetch': 2.6.11
@@ -8720,7 +8725,7 @@ snapshots:
       file-loader: 6.2.0(webpack@4.47.0)
       file-system-cache: 1.1.0
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       glob-base: 0.3.0
@@ -8735,14 +8740,14 @@ snapshots:
       micromatch: 4.0.5
       node-fetch: 2.7.0(encoding@0.1.13)
       pkg-dir: 4.2.0
-      pnp-webpack-plugin: 1.6.4(typescript@4.0.5)
+      pnp-webpack-plugin: 1.6.4(typescript@5.7.3)
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 3.0.0
       pretty-hrtime: 1.0.3
       qs: 6.12.1
       raw-loader: 4.0.2(webpack@4.47.0)
       react: 19.0.0
-      react-dev-utils: 10.2.1(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0)
+      react-dev-utils: 10.2.1(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0)
       react-dom: 19.0.0(react@19.0.0)
       regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
@@ -8782,13 +8787,13 @@ snapshots:
       npmlog: 4.1.2
       pretty-hrtime: 1.0.3
 
-  '@storybook/react@6.0.28(@babel/core@7.11.6)(@types/react@16.8.7)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@4.0.5)':
+  '@storybook/react@6.0.28(@babel/core@7.11.6)(@types/react@19.0.10)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.11.6
       '@babel/preset-flow': 7.24.1(@babel/core@7.11.6)
       '@babel/preset-react': 7.10.4(@babel/core@7.11.6)
       '@storybook/addons': 6.0.28(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@storybook/core': 6.0.28(@babel/core@7.11.6)(@types/react@16.8.7)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@4.0.5)
+      '@storybook/core': 6.0.28(@babel/core@7.11.6)(@types/react@19.0.10)(encoding@0.1.13)(eslint@9.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@storybook/node-logger': 6.0.28
       '@storybook/semver': 7.3.2
       '@svgr/webpack': 5.5.0
@@ -8801,8 +8806,8 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 19.0.0
-      react-dev-utils: 10.2.1(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0)
-      react-docgen-typescript-plugin: 0.5.2(typescript@4.0.5)(webpack@4.47.0)
+      react-dev-utils: 10.2.1(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0)
+      react-docgen-typescript-plugin: 0.5.2(typescript@5.7.3)(webpack@4.47.0)
       react-dom: 19.0.0(react@19.0.0)
       regenerator-runtime: 0.13.11
       ts-dedent: 1.2.0
@@ -8873,11 +8878,11 @@ snapshots:
   '@storybook/theming@5.3.21(react-dom@19.0.0(react@19.0.0))(react@16.14.0)':
     dependencies:
       '@emotion/core': 10.0.35(react@16.14.0)
-      '@emotion/styled': 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      '@emotion/styled': 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       '@storybook/client-logger': 5.3.21
       core-js: 3.37.0
       deep-object-diff: 1.1.9
-      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       global: 4.4.0
       memoizerific: 1.11.3
       polished: 3.7.2
@@ -8908,11 +8913,11 @@ snapshots:
     dependencies:
       '@emotion/core': 10.0.35(react@16.14.0)
       '@emotion/is-prop-valid': 0.8.8
-      '@emotion/styled': 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      '@emotion/styled': 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       '@storybook/client-logger': 6.0.28
       core-js: 3.37.0
       deep-object-diff: 1.1.9
-      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       global: 4.4.0
       memoizerific: 1.11.3
       polished: 3.7.2
@@ -8925,11 +8930,11 @@ snapshots:
     dependencies:
       '@emotion/core': 10.0.35(react@16.14.0)
       '@emotion/is-prop-valid': 0.8.8
-      '@emotion/styled': 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      '@emotion/styled': 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       '@storybook/client-logger': 6.0.28
       core-js: 3.37.0
       deep-object-diff: 1.1.9
-      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       global: 4.4.0
       memoizerific: 1.11.3
       polished: 3.7.2
@@ -8955,14 +8960,14 @@ snapshots:
       resolve-from: 5.0.0
       ts-dedent: 1.2.0
 
-  '@storybook/ui@6.0.28(@types/react@16.8.7)':
+  '@storybook/ui@6.0.28(@types/react@19.0.10)':
     dependencies:
       '@emotion/core': 10.0.35(react@16.14.0)
       '@storybook/addons': 6.0.28(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/api': 6.0.28(react-dom@16.14.0(react@16.14.0))
       '@storybook/channels': 6.0.28
       '@storybook/client-logger': 6.0.28
-      '@storybook/components': 6.0.28(@types/react@16.8.7)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@storybook/components': 6.0.28(@types/react@19.0.10)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/core-events': 6.0.28
       '@storybook/router': 6.0.28(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@storybook/semver': 7.3.2
@@ -8971,7 +8976,7 @@ snapshots:
       copy-to-clipboard: 3.3.3
       core-js: 3.37.0
       core-js-pure: 3.37.0
-      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0)
+      emotion-theming: 10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0)
       fuse.js: 3.6.1
       global: 4.4.0
       lodash: 4.17.21
@@ -9090,7 +9095,7 @@ snapshots:
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
 
   '@types/html-minifier-terser@5.1.2': {}
 
@@ -9102,7 +9107,7 @@ snapshots:
 
   '@types/markdown-to-jsx@6.11.3':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   '@types/micromatch@4.0.7':
     dependencies:
@@ -9112,22 +9117,22 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
       form-data: 4.0.0
 
-  '@types/node@12.12.70': {}
+  '@types/node@20.17.19':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/npmlog@4.1.6':
     dependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
 
   '@types/overlayscrollbars@1.12.5': {}
 
   '@types/parse-json@4.0.2': {}
-
-  '@types/prop-types@15.7.12': {}
 
   '@types/q@1.5.8': {}
 
@@ -9135,37 +9140,36 @@ snapshots:
 
   '@types/reach__router@1.3.15':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   '@types/react-color@3.0.12':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
       '@types/reactcss': 1.2.12
 
-  '@types/react-dom@17.0.9':
+  '@types/react-dom@19.0.4(@types/react@19.0.10)':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   '@types/react-syntax-highlighter@11.0.4':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   '@types/react-textarea-autosize@4.3.6':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
-  '@types/react@16.8.7':
+  '@types/react@19.0.10':
     dependencies:
-      '@types/prop-types': 15.7.12
-      csstype: 2.6.21
+      csstype: 3.1.3
 
   '@types/reactcss@1.2.12':
     dependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   '@types/resolve@0.0.8':
     dependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
 
   '@types/sinon@9.0.10':
     dependencies:
@@ -9185,27 +9189,27 @@ snapshots:
 
   '@types/webpack-sources@3.2.3':
     dependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
       '@types/source-list-map': 0.1.6
       source-map: 0.7.4
 
   '@types/webpack@4.41.38':
     dependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
       '@types/tapable': 1.0.12
       '@types/uglify-js': 3.17.5
       '@types/webpack-sources': 3.2.3
       anymatch: 3.1.3
       source-map: 0.6.1
 
-  '@vitejs/plugin-react@4.2.1(vite@5.2.10(@types/node@12.12.70)(terser@5.30.4))':
+  '@vitejs/plugin-react@4.2.1(vite@5.2.10(@types/node@20.17.19)(terser@5.30.4))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.24.4)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.4)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.1
-      vite: 5.2.10(@types/node@12.12.70)(terser@5.30.4)
+      vite: 5.2.10(@types/node@20.17.19)(terser@5.30.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -10964,6 +10968,8 @@ snapshots:
 
   csstype@2.6.21: {}
 
+  csstype@3.1.3: {}
+
   cyclist@1.0.2: {}
 
   d@1.0.2:
@@ -11195,10 +11201,10 @@ snapshots:
 
   emojis-list@3.0.0: {}
 
-  emotion-theming@10.3.0(@emotion/core@10.0.35(react@16.14.0))(react@16.14.0):
+  emotion-theming@10.3.0(@emotion/core@10.0.35(react@19.0.0))(react@16.14.0):
     dependencies:
       '@babel/runtime': 7.24.4
-      '@emotion/core': 10.0.35(react@16.14.0)
+      '@emotion/core': 10.0.35(react@19.0.0)
       '@emotion/weak-memoize': 0.2.5
       hoist-non-react-statics: 3.3.2
       react: 16.14.0
@@ -11776,7 +11782,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 3.0.7
 
-  fork-ts-checker-webpack-plugin@3.1.1(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0):
+  fork-ts-checker-webpack-plugin@3.1.1(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0):
     dependencies:
       babel-code-frame: 6.26.0
       chalk: 2.4.2
@@ -11785,7 +11791,7 @@ snapshots:
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 4.0.5
+      typescript: 5.7.3
       webpack: 4.47.0
       worker-rpc: 0.1.1
     optionalDependencies:
@@ -11793,7 +11799,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fork-ts-checker-webpack-plugin@4.1.6(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0):
+  fork-ts-checker-webpack-plugin@4.1.6(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0):
     dependencies:
       '@babel/code-frame': 7.24.2
       chalk: 2.4.2
@@ -11801,7 +11807,7 @@ snapshots:
       minimatch: 3.1.2
       semver: 5.7.2
       tapable: 1.1.3
-      typescript: 4.0.5
+      typescript: 5.7.3
       webpack: 4.47.0
       worker-rpc: 0.1.1
     optionalDependencies:
@@ -12524,7 +12530,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -13325,9 +13331,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  pnp-webpack-plugin@1.6.4(typescript@4.0.5):
+  pnp-webpack-plugin@1.6.4(typescript@5.7.3):
     dependencies:
-      ts-pnp: 1.2.0(typescript@4.0.5)
+      ts-pnp: 1.2.0(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
 
@@ -13573,7 +13579,7 @@ snapshots:
       reactcss: 1.2.3(react@19.0.0)
       tinycolor2: 1.6.0
 
-  react-dev-utils@10.2.1(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0):
+  react-dev-utils@10.2.1(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0):
     dependencies:
       '@babel/code-frame': 7.8.3
       address: 1.1.2
@@ -13584,7 +13590,7 @@ snapshots:
       escape-string-regexp: 2.0.0
       filesize: 6.0.1
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 3.1.1(eslint@9.1.1)(typescript@4.0.5)(webpack@4.47.0)
+      fork-ts-checker-webpack-plugin: 3.1.1(eslint@9.1.1)(typescript@5.7.3)(webpack@4.47.0)
       global-modules: 2.0.0
       globby: 8.0.2
       gzip-size: 5.1.1
@@ -13601,37 +13607,37 @@ snapshots:
       text-table: 0.2.0
       webpack: 4.47.0
     optionalDependencies:
-      typescript: 4.0.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
       - vue-template-compiler
 
-  react-docgen-typescript-loader@3.7.2(typescript@4.0.5)(webpack@4.47.0):
+  react-docgen-typescript-loader@3.7.2(typescript@5.7.3)(webpack@4.47.0):
     dependencies:
       '@webpack-contrib/schema-utils': 1.0.0-beta.0(webpack@4.47.0)
       loader-utils: 1.4.2
-      react-docgen-typescript: 1.22.0(typescript@4.0.5)
-      typescript: 4.0.5
+      react-docgen-typescript: 1.22.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - webpack
 
-  react-docgen-typescript-plugin@0.5.2(typescript@4.0.5)(webpack@4.47.0):
+  react-docgen-typescript-plugin@0.5.2(typescript@5.7.3)(webpack@4.47.0):
     dependencies:
       debug: 4.3.4
       endent: 2.1.0
       micromatch: 4.0.5
-      react-docgen-typescript: 1.22.0(typescript@4.0.5)
-      react-docgen-typescript-loader: 3.7.2(typescript@4.0.5)(webpack@4.47.0)
+      react-docgen-typescript: 1.22.0(typescript@5.7.3)
+      react-docgen-typescript-loader: 3.7.2(typescript@5.7.3)(webpack@4.47.0)
       tslib: 2.6.2
-      typescript: 4.0.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  react-docgen-typescript@1.22.0(typescript@4.0.5):
+  react-docgen-typescript@1.22.0(typescript@5.7.3):
     dependencies:
-      typescript: 4.0.5
+      typescript: 5.7.3
 
   react-docgen@5.4.3:
     dependencies:
@@ -13680,17 +13686,17 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-focus-lock@2.12.1(@types/react@16.8.7)(react@19.0.0):
+  react-focus-lock@2.12.1(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.24.4
       focus-lock: 1.3.5
       prop-types: 15.8.1
       react: 19.0.0
       react-clientside-effect: 1.2.6(react@19.0.0)
-      use-callback-ref: 1.3.2(@types/react@16.8.7)(react@19.0.0)
-      use-sidecar: 1.1.2(@types/react@16.8.7)(react@19.0.0)
+      use-callback-ref: 1.3.2(@types/react@19.0.10)(react@19.0.0)
+      use-sidecar: 1.1.2(@types/react@19.0.10)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   react-helmet-async@1.3.0(react-dom@16.14.0(react@16.14.0))(react@16.14.0):
     dependencies:
@@ -13803,21 +13809,21 @@ snapshots:
       prop-types: 15.8.1
       react: 19.0.0
 
-  react-textarea-autosize@8.5.3(@types/react@16.8.7)(react@16.14.0):
+  react-textarea-autosize@8.5.3(@types/react@19.0.10)(react@16.14.0):
     dependencies:
       '@babel/runtime': 7.24.4
       react: 16.14.0
       use-composed-ref: 1.3.0(react@16.14.0)
-      use-latest: 1.2.1(@types/react@16.8.7)(react@16.14.0)
+      use-latest: 1.2.1(@types/react@19.0.10)(react@16.14.0)
     transitivePeerDependencies:
       - '@types/react'
 
-  react-textarea-autosize@8.5.3(@types/react@16.8.7)(react@19.0.0):
+  react-textarea-autosize@8.5.3(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.24.4
       react: 19.0.0
       use-composed-ref: 1.3.0(react@19.0.0)
-      use-latest: 1.2.1(@types/react@16.8.7)(react@19.0.0)
+      use-latest: 1.2.1(@types/react@19.0.10)(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -14058,7 +14064,7 @@ snapshots:
       magic-string: 0.25.9
       rollup-pluginutils: 2.8.2
 
-  rollup-plugin-typescript2@0.27.3(rollup@1.32.1)(typescript@4.0.5):
+  rollup-plugin-typescript2@0.27.3(rollup@1.32.1)(typescript@5.7.3):
     dependencies:
       '@rollup/pluginutils': 3.1.0(rollup@1.32.1)
       find-cache-dir: 3.3.2
@@ -14066,7 +14072,7 @@ snapshots:
       resolve: 1.17.0
       rollup: 1.32.1
       tslib: 2.0.1
-      typescript: 4.0.5
+      typescript: 5.7.3
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -14083,7 +14089,7 @@ snapshots:
   rollup@1.32.1:
     dependencies:
       '@types/estree': 1.0.5
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
       acorn: 7.4.1
 
   rollup@4.16.4:
@@ -14730,9 +14736,9 @@ snapshots:
 
   ts-dedent@1.2.0: {}
 
-  ts-pnp@1.2.0(typescript@4.0.5):
+  ts-pnp@1.2.0(typescript@5.7.3):
     optionalDependencies:
-      typescript: 4.0.5
+      typescript: 5.7.3
 
   tslib@1.14.1: {}
 
@@ -14744,15 +14750,15 @@ snapshots:
 
   tslint-config-prettier@1.18.0: {}
 
-  tslint-plugin-prettier@2.3.0(prettier@1.19.1)(tslint@6.1.3(typescript@4.0.5)):
+  tslint-plugin-prettier@2.3.0(prettier@1.19.1)(tslint@6.1.3(typescript@5.7.3)):
     dependencies:
       eslint-plugin-prettier: 2.7.0(prettier@1.19.1)
       lines-and-columns: 1.2.4
       prettier: 1.19.1
       tslib: 1.14.1
-      tslint: 6.1.3(typescript@4.0.5)
+      tslint: 6.1.3(typescript@5.7.3)
 
-  tslint@6.1.3(typescript@4.0.5):
+  tslint@6.1.3(typescript@5.7.3):
     dependencies:
       '@babel/code-frame': 7.24.2
       builtin-modules: 1.1.1
@@ -14766,13 +14772,13 @@ snapshots:
       resolve: 1.22.8
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@4.0.5)
-      typescript: 4.0.5
+      tsutils: 2.29.0(typescript@5.7.3)
+      typescript: 5.7.3
 
-  tsutils@2.29.0(typescript@4.0.5):
+  tsutils@2.29.0(typescript@5.7.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.0.5
+      typescript: 5.7.3
 
   tty-browserify@0.0.0: {}
 
@@ -14831,7 +14837,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@4.0.5: {}
+  typescript@5.7.3: {}
 
   ua-parser-js@0.7.37: {}
 
@@ -14841,6 +14847,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  undici-types@6.19.8: {}
 
   unfetch@4.2.0: {}
 
@@ -14912,12 +14920,12 @@ snapshots:
       punycode: 1.4.1
       qs: 6.12.1
 
-  use-callback-ref@1.3.2(@types/react@16.8.7)(react@19.0.0):
+  use-callback-ref@1.3.2(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       react: 19.0.0
       tslib: 2.6.2
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   use-composed-ref@1.3.0(react@16.14.0):
     dependencies:
@@ -14927,39 +14935,39 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  use-isomorphic-layout-effect@1.1.2(@types/react@16.8.7)(react@16.14.0):
+  use-isomorphic-layout-effect@1.1.2(@types/react@19.0.10)(react@16.14.0):
     dependencies:
       react: 16.14.0
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
-  use-isomorphic-layout-effect@1.1.2(@types/react@16.8.7)(react@19.0.0):
+  use-isomorphic-layout-effect@1.1.2(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       react: 19.0.0
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
-  use-latest@1.2.1(@types/react@16.8.7)(react@16.14.0):
+  use-latest@1.2.1(@types/react@19.0.10)(react@16.14.0):
     dependencies:
       react: 16.14.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@16.8.7)(react@16.14.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@19.0.10)(react@16.14.0)
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
-  use-latest@1.2.1(@types/react@16.8.7)(react@19.0.0):
+  use-latest@1.2.1(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       react: 19.0.0
-      use-isomorphic-layout-effect: 1.1.2(@types/react@16.8.7)(react@19.0.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@19.0.10)(react@19.0.0)
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
-  use-sidecar@1.1.2(@types/react@16.8.7)(react@19.0.0):
+  use-sidecar@1.1.2(@types/react@19.0.10)(react@19.0.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 19.0.0
       tslib: 2.6.2
     optionalDependencies:
-      '@types/react': 16.8.7
+      '@types/react': 19.0.10
 
   use@3.1.1: {}
 
@@ -15004,13 +15012,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@5.2.10(@types/node@12.12.70)(terser@5.30.4):
+  vite@5.2.10(@types/node@20.17.19)(terser@5.30.4):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.16.4
     optionalDependencies:
-      '@types/node': 12.12.70
+      '@types/node': 20.17.19
       fsevents: 2.3.3
       terser: 5.30.4
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
This PR fixed the issue that make the package not usable with React 19 and Typescript. The generated typing use JSX.Element namespace that is now removed from typing of React 19. The recommended way is to use JSX.React.Element. Since this package doesn't use JSX.Element directly, simply upgrade the @types/react package will fix the generated code.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->
Playwright test all pass, obviously since this is only typing change.
Generated typing files now use the correct JSX namespace.
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->