### PR TITLE
Fix the column calculation error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,7 +131,7 @@ interface State {
 
 const clamp = (n: number, min: number, max: number): number => Math.max(Math.min(n, max), min);
 const snap = (n: number, size: number, gridGap: number): number => {
-  const v = Math.round(n / size);
+  const v = Math.round(n / (size + gridGap));
 
   return v * size + gridGap * (v - 1);
 };


### PR DESCRIPTION
以下是来自官方的示例代码，当设置gridGap大于24时，拖动后宽度计算会出现异常，本次PR做了如下修复：

The following is the sample code from the official source. When the gridGap is set to be greater than 24, an exception occurs in the width calculation after dragging. This PR has made the following fixes:

// const v = Math.round(n / size);
const v = Math.round(n / (size + gridGap));

`
        <Resizable
          style={style}
          grid={[100, 50]}
          gridGap={[3, 3]}
          defaultSize={{ width: 100, height: 50 }}
          maxWidth={306}
          maxHeight={156}
          enable={{
            top: false,
            topRight: false,
            right: true,
            bottomRight: true,
            bottom: true,
            bottomLeft: false,
            left: false,
            topLeft: false,
          }}
          onResize={a => {
            console.log(a);
          }}
        >
          001
        </Resizable>
`